### PR TITLE
[Need testing] [Hopefully] Prevent "No such interface supported"

### DIFF
--- a/CharacterMap/CharacterMap/Core/ExportManager.cs
+++ b/CharacterMap/CharacterMap/Core/ExportManager.cs
@@ -353,11 +353,7 @@ namespace CharacterMap.Core
                 {
                     try
                     {
-                        if (file.Provider.Id != "computer")
-                            await CachedFileManager.CompleteUpdatesAsync(file);
                         // 3. Write the SVG to the file
-                        else
-                            CachedFileManager.DeferUpdates(file);
                         await Utils.WriteSvgAsync(svg, file);
                         return new ExportResult(ExportState.Succeeded, file);
                     }
@@ -409,10 +405,6 @@ namespace CharacterMap.Core
                 if (await GetTargetFileAsync(selectedFont, options.Variant, selectedChar, "png", targetFolder)
                     is StorageFile file)
                 {
-                    if (file.Provider.Id != "computer")
-                        await CachedFileManager.CompleteUpdatesAsync(file);
-                    else
-                        CachedFileManager.DeferUpdates(file);
                     using var typography = options.CreateCanvasTypography();
 
                     // If the glyph is actually a PNG file inside the font we should export it directly.

--- a/CharacterMap/CharacterMap/Core/ExportManager.cs
+++ b/CharacterMap/CharacterMap/Core/ExportManager.cs
@@ -359,7 +359,7 @@ namespace CharacterMap.Core
                     }
                     finally
                     {
-                        await CachedFileManager.CompleteUpdatesAsync(file);
+
                     }
                 }
             }
@@ -441,8 +441,6 @@ namespace CharacterMap.Core
                         await renderTarget.SaveAsync(fileStream, CanvasBitmapFileFormat.Png, 1f);
                         await fileStream.FlushAsync();
                     }
-
-                    await CachedFileManager.CompleteUpdatesAsync(file);
                     return new ExportResult(ExportState.Succeeded, file);
                 }
             }

--- a/CharacterMap/CharacterMap/Core/ExportManager.cs
+++ b/CharacterMap/CharacterMap/Core/ExportManager.cs
@@ -348,13 +348,16 @@ namespace CharacterMap.Core
                     return new ExportResult(ExportState.Skipped, null);
 
                 // 2. Get the file we will save the image to.
-                if (await GetTargetFileAsync(selectedFont, options.Variant, selectedChar, "svg", targetFolder)
-                    is StorageFile file)
+                var providedFile = await GetTargetFileAsync(selectedFont, options.Variant, selectedChar, "svg", targetFolder);                
+                if (providedFile is StorageFile file)
                 {
                     try
                     {
+                        if (file.Provider.Id != "computer")
+                            await CachedFileManager.CompleteUpdatesAsync(file);
                         // 3. Write the SVG to the file
-                        CachedFileManager.DeferUpdates(file);
+                        else
+                            CachedFileManager.DeferUpdates(file);
                         await Utils.WriteSvgAsync(svg, file);
                         return new ExportResult(ExportState.Succeeded, file);
                     }

--- a/CharacterMap/CharacterMap/Core/ExportManager.cs
+++ b/CharacterMap/CharacterMap/Core/ExportManager.cs
@@ -409,7 +409,10 @@ namespace CharacterMap.Core
                 if (await GetTargetFileAsync(selectedFont, options.Variant, selectedChar, "png", targetFolder)
                     is StorageFile file)
                 {
-                    CachedFileManager.DeferUpdates(file);
+                    if (file.Provider.Id != "computer")
+                        await CachedFileManager.CompleteUpdatesAsync(file);
+                    else
+                        CachedFileManager.DeferUpdates(file);
                     using var typography = options.CreateCanvasTypography();
 
                     // If the glyph is actually a PNG file inside the font we should export it directly.


### PR DESCRIPTION
By checking if file is locally provided on computer, otherwise, ask cached manager to complete update on it right away????

Need confirming if this will solve #215 or not

Edit1: Beware that test saving same file over and over the result eventually never showed up again, until testing on other file as I tried testing on saving 🤨 emoji, error pop up on SVG save, then saving on PNG no error show up. Until saving other emoji on PNG first and error eventually showed up

Edit2: Previous codes test on on no-interface branch, as I am now testing on latest release version. Saving file on OneDrive show the error and saving on local folder show successfully saved the icon