### PR TITLE
#274 bugfix

### DIFF
--- a/CharacterMap/CharacterMap.CX/DirectText.cpp
+++ b/CharacterMap/CharacterMap.CX/DirectText.cpp
@@ -10,7 +10,6 @@
 
 using namespace CharacterMapCX;
 using namespace CharacterMapCX::Controls;
-
 using namespace Platform;
 using namespace Windows::Foundation;
 using namespace Windows::Foundation::Collections;
@@ -129,19 +128,13 @@ Windows::Foundation::Size CharacterMapCX::Controls::DirectText::MeasureOverride(
         auto fontSize = 8 > FontSize ? 8 : FontSize;
 
         /* CREATE FORMAT */
-        ComPtr<IDWriteTextFormat> tempFormat;
-        NativeInterop::_Current->m_dwriteFactory->CreateTextFormat(
-            fontFace->Properties->FamilyName->Data(),
-            NativeInterop::_Current->m_fontCollection.Get(),
-            DWRITE_FONT_WEIGHT_NORMAL,
-            DWRITE_FONT_STYLE_NORMAL,
-            DWRITE_FONT_STRETCH_NORMAL,
-            fontSize,
-            L"en-us",
-            &tempFormat);
-
-        ComPtr<IDWriteTextFormat3> idFormat;
-        ThrowIfFailed(tempFormat.As(&idFormat));
+        ComPtr<IDWriteTextFormat3> idFormat = 
+            NativeInterop::_Current->CreateIDWriteTextFormat(
+                fontFace,
+                FontWeight,
+                FontStyle,
+                FontStretch,
+                fontSize);
 
         /* Set flow direction */
         if (this->FlowDirection == Windows::UI::Xaml::FlowDirection::RightToLeft)
@@ -188,7 +181,6 @@ Windows::Foundation::Size CharacterMapCX::Controls::DirectText::MeasureOverride(
         /* Create and set properties */
         auto layout = ref new CanvasTextLayout(device, text, format, width, height);
         layout->SetTypography(0, text->Length(), typography);
-
         if (IsColorFontEnabled && !IsOverwriteCompensationEnabled)
             layout->Options = CanvasDrawTextOptions::EnableColorFont | CanvasDrawTextOptions::Clip;
         else if (IsColorFontEnabled)

--- a/CharacterMap/CharacterMap.CX/DirectText.cpp
+++ b/CharacterMap/CharacterMap.CX/DirectText.cpp
@@ -3,8 +3,10 @@
 // Implementation of the DirectText class.
 //
 
+#pragma once
 #include "pch.h"
 #include "DWriteFallbackFont.h"
+#include "NativeInterop.h"
 
 using namespace CharacterMapCX;
 using namespace CharacterMapCX::Controls;
@@ -127,33 +129,27 @@ Windows::Foundation::Size CharacterMapCX::Controls::DirectText::MeasureOverride(
         auto fontSize = 8 > FontSize ? 8 : FontSize;
 
         /* CREATE FORMAT */
-        auto format = ref new CanvasTextFormat();
+        ComPtr<IDWriteTextFormat> tempFormat;
+        NativeInterop::_Current->m_dwriteFactory->CreateTextFormat(
+            fontFace->Properties->FamilyName->Data(),
+            NativeInterop::_Current->m_fontCollection.Get(),
+            DWRITE_FONT_WEIGHT_NORMAL,
+            DWRITE_FONT_STYLE_NORMAL,
+            DWRITE_FONT_STRETCH_NORMAL,
+            fontSize,
+            L"en-us",
+            &tempFormat);
+
+        ComPtr<IDWriteTextFormat3> idFormat;
+        ThrowIfFailed(tempFormat.As(&idFormat));
+
+        /* Set flow direction */
         if (this->FlowDirection == Windows::UI::Xaml::FlowDirection::RightToLeft)
-            format->Direction = CanvasTextDirection::RightToLeftThenTopToBottom;
-        format->FontFamily = FontFamily->Source;
-        format->FontSize = fontSize;
-        format->FontWeight = FontWeight;
-        format->FontStyle = FontStyle;
-        format->FontStretch = FontStretch;
-
-        if (IsColorFontEnabled && !IsOverwriteCompensationEnabled)
-            format->Options = CanvasDrawTextOptions::EnableColorFont | CanvasDrawTextOptions::Clip;
-        else if (IsColorFontEnabled)
-            format->Options = CanvasDrawTextOptions::EnableColorFont;
-        else if (!IsCharacterFitEnabled)
-            format->Options = CanvasDrawTextOptions::Clip;
-
-        if (IsTextWrappingEnabled)
-        {
-            format->WordWrapping = CanvasWordWrapping::Character;
-            format->TrimmingGranularity = CanvasTextTrimmingGranularity::Character;
-            format->TrimmingSign = CanvasTrimmingSign::Ellipsis;
-        }
+            idFormat->SetFlowDirection(DWRITE_FLOW_DIRECTION::DWRITE_FLOW_DIRECTION_RIGHT_TO_LEFT);
 
         /* Set blank fallback font */
-        ComPtr<IDWriteTextFormat3> dformat = GetWrappedResource<IDWriteTextFormat3>(format);
         if (FallbackFont != nullptr)
-            dformat->SetFontFallback(FallbackFont->Fallback.Get());
+            idFormat->SetFontFallback(FallbackFont->Fallback.Get());
 
         /* Set Variable Font Axis */
         if (Axis != nullptr && Axis->Size > 0)
@@ -163,27 +159,36 @@ Windows::Foundation::Size CharacterMapCX::Controls::DirectText::MeasureOverride(
             {
                 values[i] = Axis->GetAt(i)->GetDWriteValue();
             }
-            dformat->SetFontAxisValues(values, Axis->Size);
+            idFormat->SetFontAxisValues(values, Axis->Size);
         }
 
-        dformat = nullptr;
-        ComPtr<IDWriteTextLayout4> dlayout;
+        /* Set trimming. Much easier to let Win2D handle this */
+        auto format = GetOrCreate<CanvasTextFormat>(idFormat.Get());
+        if (IsTextWrappingEnabled)
+        {
+            idFormat->SetWordWrapping(DWRITE_WORD_WRAPPING::DWRITE_WORD_WRAPPING_CHARACTER);
+            format->TrimmingGranularity = CanvasTextTrimmingGranularity::Character;
+            format->TrimmingSign = CanvasTrimmingSign::Ellipsis;
+        }
 
-        /* CREATE LAYOUT */
+        /* Prepare typography */
         auto typography = ref new CanvasTypography();
         if (Typography->Feature != CanvasTypographyFeatureName::None)
             typography->AddFeature(Typography->Feature, 1);
 
-
+        ComPtr<IDWriteTextLayout4> dlayout;
+        /* CREATE LAYOUT */
+        /* calculate dimensions */
         auto device = m_canvas->Device;
-
         float width = IsTextWrappingEnabled ? size.Width : m;
         float height = IsTextWrappingEnabled ? size.Height : m;
         width = min(width, m);
         height = min(height, m);
 
+        /* Create and set properties */
         auto layout = ref new CanvasTextLayout(device, text, format, width, height);
         layout->SetTypography(0, text->Length(), typography);
+
         if (IsColorFontEnabled && !IsOverwriteCompensationEnabled)
             layout->Options = CanvasDrawTextOptions::EnableColorFont | CanvasDrawTextOptions::Clip;
         else if (IsColorFontEnabled)
@@ -333,8 +338,13 @@ void DirectText::OnDraw(CanvasControl^ sender, CanvasDrawEventArgs^ args)
         // Note: something is wrong here causing the right hand side to clip slightly.
         //       currently we use 4 as a magic number to avoid this in 90% of cases.
         //       need to figure out what's up at some point.
-        left += this->ActualWidth - m_layout->DrawBounds.Width - 4;
+        left += m_canvas->ActualWidth - m_layout->DrawBounds.Width - 4;
     }
+
+    auto fam = m_layout->DefaultFontFamily;
+    auto fam2 = m_layout->GetFontFamily(0);
+    auto loc = m_layout->DefaultLocaleName;
+    m_layout->SetLocaleName(0, 1, L"en-us");
 
     args->DrawingSession->DrawTextLayout(m_layout, float2(left, top), ((SolidColorBrush^)this->Foreground)->Color);
 

--- a/CharacterMap/CharacterMap.CX/DirectWrite.cpp
+++ b/CharacterMap/CharacterMap.CX/DirectWrite.cpp
@@ -363,6 +363,8 @@ Platform::String^ DirectWrite::GetFileName(DWriteFontFace^ fontFace)
 		&& file->GetLoader(&loader) == S_OK
 		&& file->GetReferenceKey(&refKey, &keySize) == S_OK)
 	{
+		// 2. We can only get fileNames for fonts from the Local FontFileLoader.
+		//    Remote fonts have no filenames and will return nullptr
 		if (loader->QueryInterface<IDWriteLocalFontFileLoader>(&localLoader) == S_OK)
 		{
 			UINT filePathSize = 0;
@@ -375,15 +377,6 @@ Platform::String^ DirectWrite::GetFileName(DWriteFontFace^ fontFace)
 
 				delete[] namebuffer;
 			}
-		}
-		else if (loader->QueryInterface<IDWriteRemoteFontFileLoader>(&remoteLoader) == S_OK)
-		{
-			UINT filePathSize = 0;
-			UINT filePathLength = 0;
-
-			DWRITE_LOCALITY local;
-			remoteLoader->GetLocalityFromKey(refKey, keySize, &local);
-			auto t = local;
 		}
 	}
 

--- a/CharacterMap/CharacterMap.CX/DirectWrite.h
+++ b/CharacterMap/CharacterMap.CX/DirectWrite.h
@@ -18,6 +18,7 @@ using namespace Platform;
 using namespace Platform::Collections;
 using namespace Windows::Storage;
 using namespace Windows::Storage::Streams;
+using namespace CharacterMapCX;
 
 namespace CharacterMapCX
 {

--- a/CharacterMap/CharacterMap.CX/NativeInterop.cpp
+++ b/CharacterMap/CharacterMap.CX/NativeInterop.cpp
@@ -1,3 +1,4 @@
+#pragma once
 #include "pch.h"
 #include "NativeInterop.h"
 #include "CanvasTextLayoutAnalysis.h"
@@ -17,6 +18,7 @@ using namespace Platform::Collections;
 using namespace Windows::Foundation::Numerics;
 using namespace concurrency;
 
+NativeInterop^ NativeInterop::_Current = nullptr;
 
 NativeInterop::NativeInterop(CanvasDevice^ device)
 {
@@ -39,6 +41,7 @@ NativeInterop::NativeInterop(CanvasDevice^ device)
 		&m_d2dContext);
 
 	m_fontManager = new CustomFontManager(m_dwriteFactory);
+	_Current = this;
 }
 
 IAsyncAction^ NativeInterop::ListenForFontSetExpirationAsync()
@@ -82,6 +85,7 @@ DWriteFontSet^ NativeInterop::GetSystemFonts()
 
 		ThrowIfFailed(m_dwriteFactory->GetSystemFontCollection(true, DWRITE_FONT_FAMILY_MODEL_WEIGHT_STRETCH_STYLE, &fontCollection));
 		ThrowIfFailed(fontCollection->GetFontSet(&fontSet));
+		m_fontCollection = fontCollection;
 
 		ComPtr<IDWriteFontSet3> fontSet3;
 		ThrowIfFailed(fontSet.As(&fontSet3));

--- a/CharacterMap/CharacterMap.CX/NativeInterop.cpp
+++ b/CharacterMap/CharacterMap.CX/NativeInterop.cpp
@@ -69,7 +69,6 @@ IVectorView<DWriteFontSet^>^ NativeInterop::GetFonts(IVectorView<Uri^>^ uris)
 	return DirectWrite::GetFonts(uris, m_dwriteFactory);
 }
 
-
 DWriteFontSet^ NativeInterop::GetSystemFonts()
 {
 	if (m_isFontSetStale)
@@ -288,8 +287,6 @@ byte* GetPointerToPixelData(IBuffer^ pixelBuffer, unsigned int* length)
 	return pixels;
 }
 
-
-
 IAsyncOperation<bool>^ NativeInterop::UnpackWOFF2Async(IBuffer^ buffer, IOutputStream^ stream)
 {
 	// 1. Unpack the WOFF2 data
@@ -303,4 +300,29 @@ IAsyncOperation<bool>^ NativeInterop::UnpackWOFF2Async(IBuffer^ buffer, IOutputS
 		return create_async([] { return task_from_result(false); });
 	else
 		return DirectWrite::SaveFontStreamAsync(fileStream, stream);
+}
+
+CanvasTextFormat^ CharacterMapCX::NativeInterop::CreateTextFormat(DWriteFontFace^ fontFace, FontWeight weight, FontStyle style, FontStretch stretch, float fontSize)
+{
+	ComPtr<IDWriteTextFormat3> idFormat = CreateIDWriteTextFormat(fontFace, weight, style, stretch, fontSize);
+	return GetOrCreate<CanvasTextFormat>(idFormat.Get());
+}
+
+ComPtr<IDWriteTextFormat3> CharacterMapCX::NativeInterop::CreateIDWriteTextFormat(DWriteFontFace^ fontFace, FontWeight weight, FontStyle style, FontStretch stretch, float fontSize)
+{
+	ComPtr<IDWriteTextFormat> tempFormat;
+	m_dwriteFactory->CreateTextFormat(
+		fontFace->Properties->FamilyName->Data(),
+		m_fontCollection.Get(),
+		static_cast<DWRITE_FONT_WEIGHT>(weight.Weight),
+		static_cast<DWRITE_FONT_STYLE>(style),
+		static_cast<DWRITE_FONT_STRETCH>(stretch),
+		fontSize,
+		L"en-us",
+		&tempFormat);
+
+	ComPtr<IDWriteTextFormat3> idFormat;
+	ThrowIfFailed(tempFormat.As(&idFormat));
+
+	return idFormat;
 }

--- a/CharacterMap/CharacterMap.CX/NativeInterop.h
+++ b/CharacterMap/CharacterMap.CX/NativeInterop.h
@@ -1,5 +1,4 @@
 ﻿#pragma once
-
 #include <Microsoft.Graphics.Canvas.native.h>
 #include <d2d1_2.h>
 #include <d2d1_3.h>
@@ -63,18 +62,18 @@ namespace CharacterMapCX
 
 		IVectorView<DWriteFontSet^>^ GetFonts(IVectorView<Uri^>^ uris);
 
-	private:
-
-		IAsyncAction^ ListenForFontSetExpirationAsync();
-
-		bool m_isFontSetStale = true;
-		ComPtr<IDWriteFontSet3> m_systemFontSet;
-		DWriteFontSet^ m_appFontSet;
-
+	internal:
+		static NativeInterop^ _Current;
 		ComPtr<IDWriteFactory7> m_dwriteFactory;
+		ComPtr<IDWriteFontCollection3> m_fontCollection;
+
+	private:
+		ComPtr<IDWriteFontSet3> m_systemFontSet;
 		ComPtr<ID2D1Factory5> m_d2dFactory;
 		ComPtr<ID2D1DeviceContext1> m_d2dContext;
-
+		DWriteFontSet^ m_appFontSet;
+		IAsyncAction^ ListenForFontSetExpirationAsync();
+		bool m_isFontSetStale = true;
 		CustomFontManager* m_fontManager;
     };
 }

--- a/CharacterMap/CharacterMap.CX/NativeInterop.h
+++ b/CharacterMap/CharacterMap.CX/NativeInterop.h
@@ -62,13 +62,28 @@ namespace CharacterMapCX
 
 		IVectorView<DWriteFontSet^>^ GetFonts(IVectorView<Uri^>^ uris);
 
+		CanvasTextFormat^ CreateTextFormat(
+			DWriteFontFace^ fontFace,
+			FontWeight weight,
+			FontStyle style,
+			FontStretch stretch,
+			float fontSize);
+
 	internal:
+
+		ComPtr<IDWriteTextFormat3> CreateIDWriteTextFormat(
+			DWriteFontFace^ fontFace,
+			FontWeight weight,
+			FontStyle style,
+			FontStretch stretch,
+			float fontSize);
+
 		static NativeInterop^ _Current;
 		ComPtr<IDWriteFactory7> m_dwriteFactory;
 		ComPtr<IDWriteFontCollection3> m_fontCollection;
+		ComPtr<IDWriteFontSet3> m_systemFontSet;
 
 	private:
-		ComPtr<IDWriteFontSet3> m_systemFontSet;
 		ComPtr<ID2D1Factory5> m_d2dFactory;
 		ComPtr<ID2D1DeviceContext1> m_d2dContext;
 		DWriteFontSet^ m_appFontSet;

--- a/CharacterMap/CharacterMap/Core/ExportManager.Font.cs
+++ b/CharacterMap/CharacterMap/Core/ExportManager.Font.cs
@@ -141,9 +141,7 @@ namespace CharacterMap.Core
                     ext = strsrc;
             }
 
-            if (string.IsNullOrEmpty(ext))
-
-            if (scheme == ExportNamingScheme.System)
+            if (scheme == ExportNamingScheme.System && !string.IsNullOrWhiteSpace(src))
                 fileName = src;
 
             if (string.IsNullOrWhiteSpace(fileName))

--- a/CharacterMap/CharacterMap/Core/ExportManager.cs
+++ b/CharacterMap/CharacterMap/Core/ExportManager.cs
@@ -483,16 +483,15 @@ namespace CharacterMap.Core
             ExportStyle style,
             float canvasSize)
         {
-            CanvasTextLayout layout = new (Utils.CanvasDevice, $"{character}", new()
-            {
-                FontSize = options.FontSize,
-                FontFamily = options.Variant.Source,
-                FontStretch = options.Variant.DirectWriteProperties.Stretch,
-                FontWeight = options.Variant.DirectWriteProperties.Weight,
-                FontStyle = options.Variant.DirectWriteProperties.Style,
-                HorizontalAlignment = CanvasHorizontalAlignment.Center,
-                Options = style == ExportStyle.ColorGlyph ? CanvasDrawTextOptions.EnableColorFont : CanvasDrawTextOptions.Default
-            }, canvasSize, canvasSize);
+            CanvasTextFormat format = Utils.GetInterop().CreateTextFormat(
+                options.Variant.Face,
+                options.Variant.DirectWriteProperties.Weight,
+                options.Variant.DirectWriteProperties.Style,
+                options.Variant.DirectWriteProperties.Stretch,
+                options.FontSize);
+            format.HorizontalAlignment = CanvasHorizontalAlignment.Center;
+
+            CanvasTextLayout layout = new (Utils.CanvasDevice, $"{character}", format, canvasSize, canvasSize);
 
             if (style == ExportStyle.ColorGlyph)
                 layout.Options = CanvasDrawTextOptions.EnableColorFont;

--- a/CharacterMap/CharacterMap/ViewModels/SettingsViewModel.cs
+++ b/CharacterMap/CharacterMap/ViewModels/SettingsViewModel.cs
@@ -111,7 +111,7 @@ namespace CharacterMap.ViewModels
             {
                 new("Latest Update (August 2023)", // August 2023
                     "- Added support for Right-to-Left text in Type Ramp view, Quick Compare and Compare Fonts view\n" +
-                    "- Added Unicode developers tools showing Unicode codepoint and UTF-16 value\n" +
+                    "- Added Unicode developer tools showing Unicode codepoint and UTF-16 value\n" +
                     "- Added experimental COLRv1 support to Preview Pane, Type Ramp View, Quick Compare and Compare Fonts View for Windows 11 builds > 25905\n" +
                     "    • If a glyph has both COLRv1 and COLRv0 versions, only the COLRv1 version can be seen in these views\n" +
                     "    • SVG Export or copying as SVG will only use COLRv0 glyphs\n" +
@@ -125,7 +125,7 @@ namespace CharacterMap.ViewModels
                     "- Added ability to open and import WOFF2 fonts (WOFF2 fonts are converted to OTF during import)\n" +
                     "- Added font PANOSE information to Font Properties flyout"),
                 new("2023.2.4.0 (Mar 2023)", // March 2023
-                    "- Add ability to add default preview strings for Type Ramp view and Compare window through the context menu on the suggestion box or inside Settings view"),
+                    "- Add ability to add default preview strings for Type Ramp view and Compare window through the suggestions popup or inside Settings view"),
                 new("2023.1.2.0 (Jan 2023)", // Jan 2023
                     "- Added tabbed interface support to the Windows 11 theme\n" +
                     "- Added ability to compare all faces in a font family from Font List context menu or the \"...\" menu"),

--- a/CharacterMap/CharacterMap/Views/FontMapView.xaml
+++ b/CharacterMap/CharacterMap/Views/FontMapView.xaml
@@ -1527,7 +1527,7 @@
                                 x:Name="TxtPreview"
                                 VerticalAlignment="Center"
                                 FontFace="{Binding SelectedVariant.Face}"
-                                FontFamily="{Binding FontFamily}"
+                                FontFamily="{Binding SelectedVariant.Source}"
                                 FontSize="24"
                                 FontStretch="{Binding SelectedVariant.DirectWriteProperties.Stretch}"
                                 FontStyle="{Binding SelectedVariant.DirectWriteProperties.Style}"

--- a/CharacterMap/CharacterMap/Views/FontMapView.xaml
+++ b/CharacterMap/CharacterMap/Views/FontMapView.xaml
@@ -774,27 +774,38 @@
                                                     Style="{StaticResource Value}"
                                                     Text="{x:Bind ViewModel.SelectedVariantAnalysis.COLRVersion, Mode=OneWay}" />
 
-                                                <!--<TextBlock x:Uid="FontPropInstallType" />
-                                                <TextBlock Style="{StaticResource Value}" Text="{x:Bind ViewModel.SelectedVariant.GetProviderName(), Mode=OneWay}" />-->
-
                                                 <TextBlock x:Uid="FontPropFileSize" />
                                                 <TextBlock Style="{StaticResource Value}" Text="{x:Bind core:Converters.GetFileSize(ViewModel.SelectedVariantAnalysis.FileSize), Mode=OneWay}" />
 
+                                                <TextBlock
+                                                    x:Name="FontPropSrc"
+                                                    x:Load="{x:Bind ViewModel.SelectedVariant.DirectWriteProperties.IsRemote, Mode=OneWay, FallbackValue=False}"
+                                                    x:Uid="FontPropInstallType"
+                                                    d:Text="Install Type" />
+                                                <TextBlock
+                                                    x:Name="FontPropSrcValue"
+                                                    x:Load="{x:Bind ViewModel.SelectedVariant.DirectWriteProperties.IsRemote, Mode=OneWay, FallbackValue=False}"
+                                                    Style="{StaticResource Value}"
+                                                    Text="{core:Localizer Key='DWriteSourceRemoteFontProvider'}" />
 
+
+                                                <!--<TextBlock x:Uid="FontPropInstallType" />
+                                                <TextBlock Style="{StaticResource Value}" Text="{x:Bind ViewModel.SelectedVariant.GetProviderName(), Mode=OneWay}" />-->
 
                                                 <TextBlock
                                                     x:Name="FontPropXaml"
+                                                    x:Load="{x:Bind ViewModel.SelectedVariant.IsImported, Mode=OneWay, FallbackValue=False}"
                                                     x:Uid="FontPropXaml"
-                                                    Padding="0,4,0,0"
-                                                    Visibility="{x:Bind ViewModel.SelectedVariant.IsImported, Mode=OneWay, FallbackValue=Collapsed}" />
+                                                    Padding="0,4,0,0" />
 
                                                 <TextBlock
+                                                    x:Name="FontPropXamlValue"
+                                                    x:Load="{x:Bind ViewModel.SelectedVariant.IsImported, Mode=OneWay, FallbackValue=False}"
                                                     Grid.Column="0"
                                                     Grid.ColumnSpan="2"
                                                     Margin="0,-4,0,0"
                                                     Style="{StaticResource Value}"
-                                                    Text="{x:Bind ViewModel.XamlPath, Mode=OneWay}"
-                                                    Visibility="{x:Bind ViewModel.SelectedVariant.IsImported, Mode=OneWay, FallbackValue=Collapsed}" />
+                                                    Text="{x:Bind ViewModel.XamlPath, Mode=OneWay}" />
 
                                                 <TextBlock x:Uid="FontPropFilePath" Visibility="{x:Bind ShowFilePath(ViewModel.SelectedVariantAnalysis.FilePath, ViewModel.SelectedVariant.IsImported), Mode=OneWay, FallbackValue=Collapsed}" />
                                                 <TextBlock
@@ -1278,7 +1289,7 @@
                 Transform3D="{StaticResource Perspective}"
                 Visibility="Collapsed"
                 d:Background="Green"
-                d:Visibility="Visible">
+                d:Visibility="Collapsed">
                 <Grid.RenderTransform>
                     <CompositeTransform />
                 </Grid.RenderTransform>


### PR DESCRIPTION
## Problem 
The latest build broke the character preview pane for certain fonts that come from Remote Font Providers (probably Office?)

## Reason
We switched over to use DirectWrite (via a Win2D canvas control) to render the text to enable both COLRv1 and to make sure glyphs fit inside display area. 

Our DirectWrite code used Win2D's CanvasTextFormat to create our IDWriteTextFormat - but this uses a different SystemFontSet from the one we use to show the font list.

Our font loading code creates our own FontSet directly from an IDWriteFactory and includes remote fonts, which Win2D's internal FontSet does not. Due to this, Win2D's IDWriteTextFormat can't actually load remote fonts from our manual FontSet because those fonts are not contained in the FontSet Win2D uses by default.

## Solution
We use our own IDWriteFactory to create our own IDWriteTextFormats directly, and assign them our own FontSet that contains remote fonts. We can then convert this to a Win2D CanvasTextFormat where needed, where it will retain our underlying IDWriteTextFormat.