### PR TITLE
Aug 23 bugfix2

### DIFF
--- a/CharacterMap/CharacterMap.CX/DWriteFontFace.h
+++ b/CharacterMap/CharacterMap.CX/DWriteFontFace.h
@@ -124,7 +124,21 @@ namespace CharacterMapCX
 		{
 			m_font = font;
 			m_dwProperties = properties;
+
 		};
+
+		ComPtr<IDWriteFontCollection3> GetFontCollection()
+		{
+			ComPtr<IDWriteFontFamily> family;
+			m_font->GetFontFamily(&family);
+
+			ComPtr<IDWriteFontCollection> col;
+			family->GetFontCollection(&col);
+
+			ComPtr<IDWriteFontCollection3> fontCollection;
+			col.As<IDWriteFontCollection3>(&fontCollection);
+			return fontCollection;
+		}
 
 		void Realize()
 		{

--- a/CharacterMap/CharacterMap.CX/DWriteFontFamily.h
+++ b/CharacterMap/CharacterMap.CX/DWriteFontFamily.h
@@ -20,5 +20,6 @@ namespace CharacterMapCX
 
 	private:
 		ComPtr<IDWriteFontFamily2> m_family = nullptr;
+		ComPtr<IDWriteFontCollection3> m_collection = nullptr;
 	};
 }

--- a/CharacterMap/CharacterMap.CX/NativeInterop.cpp
+++ b/CharacterMap/CharacterMap.CX/NativeInterop.cpp
@@ -313,7 +313,7 @@ ComPtr<IDWriteTextFormat3> CharacterMapCX::NativeInterop::CreateIDWriteTextForma
 	ComPtr<IDWriteTextFormat> tempFormat;
 	m_dwriteFactory->CreateTextFormat(
 		fontFace->Properties->FamilyName->Data(),
-		m_fontCollection.Get(),
+		fontFace->GetFontCollection().Get(),
 		static_cast<DWRITE_FONT_WEIGHT>(weight.Weight),
 		static_cast<DWRITE_FONT_STYLE>(style),
 		static_cast<DWRITE_FONT_STRETCH>(stretch),


### PR DESCRIPTION
## Problem 
The previous bug fix broke character pane preview for fonts *not* installed in the system - i.e. font files opened using Open Font menu item .

## Fix 
We now load IDWriteFontCollection from each individual IDWriteFont on demand, rather than using our system font set collection (which only includes fonts loaded on start up)

## Other
Also includes a potential workaround for #275 (though there is no reasonable explanation for the app to ever get in this state without some unsupported modifications)

