### PR TITLE
Dec23

### DIFF
--- a/CharacterMap/CharacterMap/CharacterMap.csproj
+++ b/CharacterMap/CharacterMap/CharacterMap.csproj
@@ -198,6 +198,7 @@
     <Compile Include="Controls\CharacterGridView.cs" />
     <Compile Include="Controls\CharacterPicker.cs" />
     <Compile Include="Controls\ContentGroup.cs" />
+    <Compile Include="Controls\ControlBase.cs" />
     <Compile Include="Controls\CreateCollectionDialog.xaml.cs">
       <DependentUpon>CreateCollectionDialog.xaml</DependentUpon>
     </Compile>

--- a/CharacterMap/CharacterMap/CharacterMap.csproj
+++ b/CharacterMap/CharacterMap/CharacterMap.csproj
@@ -15,7 +15,7 @@
     <TargetPlatformVersion Condition=" '$(TargetPlatformVersion)' == '' ">10.0.20348.0</TargetPlatformVersion>
     <TargetPlatformMinVersion>10.0.19041.0</TargetPlatformMinVersion>
     <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12</LangVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{A5A43C5B-DE2A-4C0C-9213-0A381AF9435A};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <WindowsXamlEnableOverview>true</WindowsXamlEnableOverview>

--- a/CharacterMap/CharacterMap/Controls/CharacterGridView.cs
+++ b/CharacterMap/CharacterMap/Controls/CharacterGridView.cs
@@ -9,6 +9,8 @@ using Windows.UI.Xaml.Hosting;
 using Windows.UI.Xaml.Markup;
 using Windows.UI.Xaml.Media;
 
+using CGV = CharacterMap.Controls.CharacterGridView;
+
 namespace CharacterMap.Controls;
 
 internal class CharacterGridViewTemplateSettings
@@ -37,11 +39,10 @@ public class CharacterGridView : GridView
         set { SetValue(ItemSizeProperty, value); }
     }
 
-    public static readonly DependencyProperty ItemSizeProperty =
-        DependencyProperty.Register(nameof(ItemSize), typeof(double), typeof(CharacterGridView), new PropertyMetadata(0d, (d, e) =>
-        {
-            ((CharacterGridView)d)._templateSettings.Size = (double)e.NewValue;
-        }));
+    public static readonly DP ItemSizeProperty = DP<double, CGV>(0d, (d, o, n) =>
+    {
+        d._templateSettings.Size = n;
+    });
 
     #endregion
 
@@ -53,11 +54,10 @@ public class CharacterGridView : GridView
         set { SetValue(ItemFontFamilyProperty, value); }
     }
 
-    public static readonly DependencyProperty ItemFontFamilyProperty =
-        DependencyProperty.Register(nameof(ItemFontFamily), typeof(FontFamily), typeof(CharacterGridView), new PropertyMetadata(null, (d, e) =>
-        {
-            ((CharacterGridView)d)._templateSettings.FontFamily = (FontFamily)e.NewValue;
-        }));
+    public static readonly DP ItemFontFamilyProperty = DP<FontFamily, CGV>(null, (d, o, n) =>
+    {
+        d._templateSettings.FontFamily = n;
+    });
 
     #endregion
 
@@ -69,11 +69,10 @@ public class CharacterGridView : GridView
         set { SetValue(ItemFontFaceProperty, value); }
     }
 
-    public static readonly DependencyProperty ItemFontFaceProperty =
-        DependencyProperty.Register(nameof(ItemFontFace), typeof(DWriteFontFace), typeof(CharacterGridView), new PropertyMetadata(null, (d, e) =>
-        {
-            ((CharacterGridView)d)._templateSettings.FontFace = (DWriteFontFace)e.NewValue;
-        }));
+    public static readonly DP ItemFontFaceProperty = DP<DWriteFontFace, CGV>(null, (d, o, n) =>
+    {
+        d._templateSettings.FontFace = n;
+    });
 
     #endregion
 
@@ -85,15 +84,15 @@ public class CharacterGridView : GridView
         set { SetValue(ItemTypographyProperty, value); }
     }
 
-    public static readonly DependencyProperty ItemTypographyProperty =
-        DependencyProperty.Register(nameof(ItemTypography), typeof(TypographyFeatureInfo), typeof(CharacterGridView), new PropertyMetadata(null, (d, e) =>
+    public static readonly DP ItemTypographyProperty = DP<TypographyFeatureInfo, CGV>(null, (d, o, n) =>
+    {
+        if (n is not null)
         {
-            if (d is CharacterGridView g && e.NewValue is TypographyFeatureInfo t)
-            {
-                g._templateSettings.Typography = t;
-                g.UpdateTypographies(t);
-            }
-        }));
+            d._templateSettings.Typography = n;
+            d.UpdateTypographies(n);
+        }
+
+    });
 
     #endregion
 
@@ -105,15 +104,11 @@ public class CharacterGridView : GridView
         set { SetValue(ShowColorGlyphsProperty, value); }
     }
 
-    public static readonly DependencyProperty ShowColorGlyphsProperty =
-        DependencyProperty.Register(nameof(ShowColorGlyphs), typeof(bool), typeof(CharacterGridView), new PropertyMetadata(false, (d, e) =>
-        {
-            if (d is CharacterGridView g && e.NewValue is bool b)
-            {
-                g._templateSettings.ShowColorGlyphs = b;
-                g.UpdateColorsFonts(b);
-            }
-        }));
+    public static readonly DP ShowColorGlyphsProperty = DP<bool, CGV>(false, (d, o, n) =>
+    {
+        d._templateSettings.ShowColorGlyphs = n;
+        d.UpdateColorsFonts(n);
+    });
 
     #endregion
 
@@ -125,19 +120,11 @@ public class CharacterGridView : GridView
         set { SetValue(ItemAnnotationProperty, value); }
     }
 
-    // Using a DependencyProperty as the backing store for ItemAnnotation.  This enables animation, styling, binding, etc...
-    public static readonly DependencyProperty ItemAnnotationProperty =
-        DependencyProperty.Register("ItemAnnotation", typeof(GlyphAnnotation), typeof(CharacterGridView), new PropertyMetadata(GlyphAnnotation.None, (d, e) =>
-        {
-            if (d is CharacterGridView g && e.NewValue is GlyphAnnotation b)
-            {
-                g._templateSettings.Annotation = b;
-                g.UpdateUnicode(b);
-            }
-        }));
-
-
-
+    public static readonly DP ItemAnnotationProperty = DP<GlyphAnnotation, CGV>(GlyphAnnotation.None, (d, o, n) =>
+    {
+        d._templateSettings.Annotation = n;
+        d.UpdateUnicode(n);
+    });
 
     #endregion
 
@@ -149,16 +136,12 @@ public class CharacterGridView : GridView
         set { SetValue(EnableResizeAnimationProperty, value); }
     }
 
-    public static readonly DependencyProperty EnableResizeAnimationProperty =
-        DependencyProperty.Register(nameof(EnableResizeAnimation), typeof(bool), typeof(CharacterGridView), new PropertyMetadata(false, (d, e) =>
-        {
-            if (d is CharacterGridView g && e.NewValue is bool b)
-            {
-                g._templateSettings.EnableReposition = b && CompositionFactory.UISettings.AnimationsEnabled;
-                g.UpdateAnimation(b);
-            }
-        }));
-
+    public static readonly DP EnableResizeAnimationProperty = DP<bool, CGV>(false, (d, o, n) =>
+    {
+        d._templateSettings.EnableReposition = n && CompositionFactory.UISettings.AnimationsEnabled;
+        d.UpdateAnimation(n);
+    });
+      
     #endregion
 
     #region ItemFontVariant
@@ -169,8 +152,7 @@ public class CharacterGridView : GridView
         set { SetValue(ItemFontVariantProperty, value); }
     }
 
-    public static readonly DependencyProperty ItemFontVariantProperty =
-        DependencyProperty.Register(nameof(ItemFontVariant), typeof(FontVariant), typeof(CharacterGridView), new PropertyMetadata(null));
+    public static readonly DP ItemFontVariantProperty = DP<FontVariant, CGV>();
 
     #endregion
 
@@ -183,7 +165,7 @@ public class CharacterGridView : GridView
     public CharacterGridView()
     {
         _xamlDirect = XamlDirect.GetDefault();
-        _templateSettings = new CharacterGridViewTemplateSettings();
+        _templateSettings = new ();
 
         this.ContainerContentChanging += OnContainerContentChanging;
         this.ChoosingItemContainer += OnChoosingItemContainer;

--- a/CharacterMap/CharacterMap/Controls/ControlBase.cs
+++ b/CharacterMap/CharacterMap/Controls/ControlBase.cs
@@ -1,0 +1,156 @@
+﻿using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+
+namespace CharacterMap.Controls;
+
+public abstract class ControlBase : Control
+{
+    public static PropertyMetadata NullMetadata { get; } = new(null);
+
+    public delegate void DPChangedCallback<V, T>(T source, V oldValue, V newValue);
+
+    int _loadCount = 0;
+
+    public bool IsActualLoaded
+    {
+        get => (bool)GetValue(IsActualLoadedProperty);
+        private set => SetValue(IsActualLoadedProperty, value);
+    }
+
+    public static readonly DP IsActualLoadedProperty = DP<bool, ControlBase>(false);
+
+    public ControlBase()
+    {
+        this.Loaded += ControlBase_Loaded;
+        this.Unloaded += ControlBase_Unloaded;
+    }
+
+    #region Loaded
+
+    private void ControlBase_Loaded(object sender, RoutedEventArgs e)
+    {
+        _loadCount++;
+        if (_loadCount == 1)
+            OnLoaded();
+    }
+
+    private void ControlBase_Unloaded(object sender, RoutedEventArgs e)
+    {
+        _loadCount++;
+        if (_loadCount == 0)
+            OnUnloaded();
+    }
+
+    protected virtual void OnLoaded() { }
+
+    protected virtual void OnUnloaded() { }
+
+
+    #endregion
+
+    #region DP
+    public static DependencyProperty DP<V, T>(V defaultValue, DPChangedCallback<V, T> callback = null, [CallerMemberName] string name = null) where T : DependencyObject
+    {
+        PropertyChangedCallback c = null;
+        if (callback != null)
+        {
+            c = (d, e) =>
+            {
+                callback.Invoke(
+                    (T)d,
+                    e.OldValue is V oldV ? oldV : default,
+                    e.NewValue is V newV ? newV : default);
+            };
+        }
+
+        return DependencyProperty.Register(name.Remove(name.Length - 8), typeof(V), typeof(T), new PropertyMetadata(defaultValue, c));
+    }
+
+    public static DependencyProperty DP<V, T>(V defaultValue, Action<T> callback, [CallerMemberName] string name = null) where T : DependencyObject
+    {
+        PropertyChangedCallback c = null;
+        if (callback != null)
+        {
+            c = (d, e) =>
+            {
+                callback.Invoke((T)d);
+            };
+        }
+
+        return DependencyProperty.Register(name.Remove(name.Length - 8), typeof(V), typeof(T), new PropertyMetadata(defaultValue, c));
+    }
+
+    public static DependencyProperty DP<V, T>(V defaultValue, PropertyChangedCallback callback, [CallerMemberName] string name = null) where T : DependencyObject
+    {
+        return DependencyProperty.Register(name.Remove(name.Length - 8), typeof(V), typeof(T), new PropertyMetadata(defaultValue, callback));
+    }
+
+    public static DependencyProperty DP<V, Y>(PropertyMetadata metadata = null, [CallerMemberName] string name = null)
+    {
+        return DependencyProperty.Register(name.Remove(name.Length - 8), typeof(V), typeof(Y), metadata ?? NullMetadata);
+    }
+
+
+
+    public static DependencyProperty DP<V, Y>(PropertyChangedCallback callback, [CallerMemberName] string name = null)
+    {
+        return DependencyProperty.Register(name.Remove(name.Length - 8), typeof(V), typeof(Y), new PropertyMetadata(null, callback));
+    }
+
+    #endregion
+
+    #region AP
+
+    /// <summary>
+    /// Registers an AttachedProperty
+    /// </summary>
+    /// <typeparam name="V">Property Type</typeparam>
+    /// <typeparam name="Y">Owner Type</typeparam>
+    /// <param name="metadata"></param>
+    /// <param name="name">Property Name. Leave blank.</param>
+    /// <returns></returns>
+    public static DependencyProperty AP<V, Y>(PropertyMetadata metadata = null, [CallerMemberName] string name = null)
+    {
+        return DependencyProperty.RegisterAttached(name.Remove(name.Length - 8), typeof(V), typeof(Y), metadata ?? NullMetadata);
+    }
+
+    public static DP AP<V, Y>(V defaultValue, PropertyChangedCallback callback, [CallerMemberName] string name = null)
+    {
+        return DependencyProperty.RegisterAttached(name.Remove(name.Length - 8), typeof(V), typeof(Y), new PropertyMetadata(defaultValue, callback));
+    }
+
+    #endregion
+}
+
+public abstract class ControlBase<T> : ControlBase where T : DependencyObject
+{
+    protected static DP DP<V>(V defaultValue, Action<T> callback, [CallerMemberName] string name = null)
+    {
+        return DP<V, T>(defaultValue, callback, name);
+    }
+
+    protected static DP DP<V>(V defaultValue, DPChangedCallback<V, T> callback = null, [CallerMemberName] string name = null)
+    {
+        return DP<V, T>(defaultValue, callback, name);
+    }
+
+    protected static DP DP<V>(PropertyMetadata metadata = null, [CallerMemberName] string name = null)
+    {
+        return DP<V, T>(metadata, name);
+    }
+
+    public static DependencyProperty AP<V>(V defaultValue, [CallerMemberName] string name = null)
+    {
+        return AP<V, T>(new PropertyMetadata(defaultValue), name);
+    }
+
+    public static DependencyProperty AP<V>(PropertyMetadata metadata = null, [CallerMemberName] string name = null)
+    {
+        return AP<V, T>(metadata, name);
+    }
+
+    public static DP AP<V>(V defaultValue, PropertyChangedCallback callback, [CallerMemberName] string name = null)
+    {
+        return AP<V, T>(defaultValue, callback, name);
+    }
+}

--- a/CharacterMap/CharacterMap/Controls/SettingsPresenter.cs
+++ b/CharacterMap/CharacterMap/Controls/SettingsPresenter.cs
@@ -197,19 +197,19 @@ public sealed class SettingsPresenter : ItemsControl, IThemeableControl
 
     void UpdatePlacementStates()
     {
-        VisualStateManager.GoToState(this, $"{ContentPlacement}PlacementState", true);
+        VisualStateManager.GoToState(this, $"{ContentPlacement}PlacementState", ResourceHelper.AllowAnimation);
     }
 
     void UpdateIconStates()
     {
         string state = Icon is null ? "NoIconState" : "IconState";
-        VisualStateManager.GoToState(this, state, true);
+        VisualStateManager.GoToState(this, state, ResourceHelper.AllowAnimation);
     }
 
     private void UpdateDescriptionStates()
     {
         string state = Description is null ? "NoDescriptionState" : "DescriptionState";
-        VisualStateManager.GoToState(this, state, true);
+        VisualStateManager.GoToState(this, state, ResourceHelper.AllowAnimation);
     }
 
     public void UpdateTheme()

--- a/CharacterMap/CharacterMap/Controls/Toolkit/GridSplitter.cs
+++ b/CharacterMap/CharacterMap/Controls/Toolkit/GridSplitter.cs
@@ -237,7 +237,7 @@ public partial class GridSplitter : Control
     {
         _dragging = false;
         _pressed = false;
-        VisualStateManager.GoToState(this, _pointerEntered ? "PointerOver" : "Normal", true);
+        VisualStateManager.GoToState(this, _pointerEntered ? "PointerOver" : "Normal", ResourceHelper.AllowAnimation);
     }
 
     private void GridSplitter_ManipulationStarted(object sender, ManipulationStartedRoutedEventArgs e)

--- a/CharacterMap/CharacterMap/Controls/XamlTitleBar.cs
+++ b/CharacterMap/CharacterMap/Controls/XamlTitleBar.cs
@@ -351,9 +351,9 @@ public sealed class XamlTitleBar : ContentControl
     private void UpdateStates()
     {
         if (IsDragTarget)
-            VisualStateManager.GoToState(this, "ActiveState", true);
+            VisualStateManager.GoToState(this, "ActiveState", ResourceHelper.AllowAnimation);
         else
-            VisualStateManager.GoToState(this, "InactiveState", true);
+            VisualStateManager.GoToState(this, "InactiveState", ResourceHelper.AllowAnimation);
     }
 
     private void UpdateDragElement()

--- a/CharacterMap/CharacterMap/Core/Utils.cs
+++ b/CharacterMap/CharacterMap/Core/Utils.cs
@@ -200,6 +200,8 @@ public static class Utils
 
     public static bool TryParseHexString(string hexNumber, out int hex)
     {
+        if (hexNumber.StartsWith("U+", StringComparison.OrdinalIgnoreCase))
+            hexNumber = hexNumber.Remove(0, 2);
         hexNumber = hexNumber.Replace("x", string.Empty);
         if (int.TryParse(hexNumber, NumberStyles.HexNumber, null, out int result))
         {

--- a/CharacterMap/CharacterMap/GlobalSuppressions.cs
+++ b/CharacterMap/CharacterMap/GlobalSuppressions.cs
@@ -32,6 +32,9 @@ global using Windows.Storage;
 global using Windows.Storage.Pickers;
 global using Windows.Storage.Streams;
 
+global using static CharacterMap.Controls.ControlBase;
+global using DP = Windows.UI.Xaml.DependencyProperty;
+
 using System.Diagnostics.CodeAnalysis;
 
 [assembly: SuppressMessage("Naming", "VSSpell001:Spell Check", Justification = "BritishEnglish", Scope = "member", Target = "~P:CharacterMap.Core.FontVariant.SupportsColourRendering")]

--- a/CharacterMap/CharacterMap/Helpers/FlyoutHelper.cs
+++ b/CharacterMap/CharacterMap/Helpers/FlyoutHelper.cs
@@ -497,8 +497,10 @@ public static class FlyoutHelper
     /// <param name="menu"></param>
     /// <param name="target"></param>
     /// <param name="viewmodel"></param>
-    public static void ShowCharacterGridContext(MenuFlyout menu, FrameworkElement target, FontMapViewModel viewmodel)
+    public static void ShowCharacterGridContext(MenuFlyout menu, FrameworkElement target, FontMapViewModel viewmodel, bool isStandalone)
     {
+        T Child<T>(string name) where T : MenuFlyoutItemBase => menu.Items.OfType<T>().FirstOrDefault(c => c.Name == name);
+
         if (target.Tag is Character c)
         {
             Style style = ResourceHelper.Get<Style>("ThemeMenuFlyoutItemStyle");
@@ -511,7 +513,7 @@ public static class FlyoutHelper
             var analysis = viewmodel.GetCharAnalysis(c);
 
             // 3. Handle PNG options
-            var pngRoot = menu.Items.OfType<MenuFlyoutSubItem>().FirstOrDefault(i => i.Name == "PngRoot");
+            var pngRoot = Child<MenuFlyoutSubItem>("PngRoot");
             foreach (var child in pngRoot.Items.OfType<MenuFlyoutItem>())
             {
                 if (child.CommandParameter is ExportStyle s && s == ExportStyle.ColorGlyph)
@@ -521,7 +523,7 @@ public static class FlyoutHelper
             }
 
             // 4. Handle SVG options
-            var svgRoot = menu.Items.OfType<MenuFlyoutSubItem>().FirstOrDefault(i => i.Name == "SvgRoot");
+            var svgRoot = Child<MenuFlyoutSubItem>("SvgRoot");
 
             // 4.1. We can only save as SVG if all layers of the glyph are created with vectors
             svgRoot.SetVisible(analysis.IsFullVectorBased);
@@ -545,8 +547,11 @@ public static class FlyoutHelper
                 }
             }
 
+            // 4.2. Find in other fonts is only supported in MainView right now
+            Child<MenuFlyoutItem>("FindCharButton")?.SetVisible(!isStandalone);
+
             // 5. Handle Dev values
-            if (menu.Items.OfType<MenuFlyoutSubItem>().FirstOrDefault(i => i.Name == "DevRoot") is MenuFlyoutSubItem devRoot)
+            if (Child<MenuFlyoutSubItem>("DevRoot") is { } devRoot)
             {
                 // 5.0. Prepare click handler
                 static void CopyItemClick(object sender, RoutedEventArgs e)
@@ -598,10 +603,8 @@ public static class FlyoutHelper
             };
 
             // 6. Handle visibility of "Add to Selection" Button
-            if (menu.Items.OfType<MenuFlyoutItem>().FirstOrDefault(i => i.Name == "AddSelectionButton") is MenuFlyoutItem add)
-            {
+            if (Child<MenuFlyoutItem>("AddSelectionButton") is { } add)
                 add.SetVisible(ResourceHelper.AppSettings.EnableCopyPane);
-            }
 
             // 7. Set item context
             menu.SetItemsDataContext(target.Tag, subStyle);

--- a/CharacterMap/CharacterMap/Models/BasicFontFilter.cs
+++ b/CharacterMap/CharacterMap/Models/BasicFontFilter.cs
@@ -30,6 +30,12 @@ public partial class BasicFontFilter
             true);
     }
 
+    public static BasicFontFilter ForChar(Character ch)
+    {
+        return new BasicFontFilter((f, c) => f.Where(v => v.Variants.Any(
+            v => Unicode.ContainsRange(v, new UnicodeRange(ch.UnicodeIndex, ch.UnicodeIndex)))), null);
+    }
+
     public static BasicFontFilter ForRange(UnicodeRange range, string displayTitle)
     {
         return new BasicFontFilter((f, c) => f.Where(v => v.Variants.Any(v => Unicode.ContainsRange(v, range))), displayTitle);

--- a/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.de-DE.xlf
+++ b/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.de-DE.xlf
@@ -2032,6 +2032,10 @@ If an ideograph has multiple entries, it means that the ideograph has multiple d
           <source>Choose existing</source>
           <target state="new">Choose existing</target>
         </trans-unit>
+        <trans-unit id="FindCharButton.Text" translate="yes" xml:space="preserve">
+          <source>Find in other fonts</source>
+          <target state="new">Find in other fonts</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.en-GB.xlf
+++ b/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.en-GB.xlf
@@ -2031,6 +2031,10 @@ If an ideograph has multiple entries, it means that the ideograph has multiple d
           <source>Choose existing</source>
           <target state="new">Choose existing</target>
         </trans-unit>
+        <trans-unit id="FindCharButton.Text" translate="yes" xml:space="preserve">
+          <source>Find in other fonts</source>
+          <target state="new">Find in other fonts</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.fr-FR.xlf
+++ b/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.fr-FR.xlf
@@ -2033,6 +2033,10 @@ If an ideograph has multiple entries, it means that the ideograph has multiple d
           <source>Choose existing</source>
           <target state="new">Choose existing</target>
         </trans-unit>
+        <trans-unit id="FindCharButton.Text" translate="yes" xml:space="preserve">
+          <source>Find in other fonts</source>
+          <target state="new">Find in other fonts</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.it-IT.xlf
+++ b/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.it-IT.xlf
@@ -2037,6 +2037,10 @@ If an ideograph has multiple entries, it means that the ideograph has multiple d
           <source>Choose existing</source>
           <target state="new">Choose existing</target>
         </trans-unit>
+        <trans-unit id="FindCharButton.Text" translate="yes" xml:space="preserve">
+          <source>Find in other fonts</source>
+          <target state="new">Find in other fonts</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.pl-PL.xlf
+++ b/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.pl-PL.xlf
@@ -2035,6 +2035,10 @@ If an ideograph has multiple entries, it means that the ideograph has multiple d
           <source>Choose existing</source>
           <target state="new">Choose existing</target>
         </trans-unit>
+        <trans-unit id="FindCharButton.Text" translate="yes" xml:space="preserve">
+          <source>Find in other fonts</source>
+          <target state="new">Find in other fonts</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.ru-RU.xlf
+++ b/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.ru-RU.xlf
@@ -2033,6 +2033,10 @@ If an ideograph has multiple entries, it means that the ideograph has multiple d
           <source>Choose existing</source>
           <target state="new">Choose existing</target>
         </trans-unit>
+        <trans-unit id="FindCharButton.Text" translate="yes" xml:space="preserve">
+          <source>Find in other fonts</source>
+          <target state="new">Find in other fonts</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.ta.xlf
+++ b/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.ta.xlf
@@ -2045,6 +2045,10 @@ If an ideograph has multiple entries, it means that the ideograph has multiple d
           <source>Choose existing</source>
           <target state="new">Choose existing</target>
         </trans-unit>
+        <trans-unit id="FindCharButton.Text" translate="yes" xml:space="preserve">
+          <source>Find in other fonts</source>
+          <target state="new">Find in other fonts</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.th-TH.xlf
+++ b/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.th-TH.xlf
@@ -2040,6 +2040,10 @@ If an ideograph has multiple entries, it means that the ideograph has multiple d
           <source>Choose existing</source>
           <target state="new">Choose existing</target>
         </trans-unit>
+        <trans-unit id="FindCharButton.Text" translate="yes" xml:space="preserve">
+          <source>Find in other fonts</source>
+          <target state="new">Find in other fonts</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.zh-CN.xlf
+++ b/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.zh-CN.xlf
@@ -2047,6 +2047,10 @@ If an ideograph has multiple entries, it means that the ideograph has multiple d
           <source>Choose existing</source>
           <target state="new">Choose existing</target>
         </trans-unit>
+        <trans-unit id="FindCharButton.Text" translate="yes" xml:space="preserve">
+          <source>Find in other fonts</source>
+          <target state="new">Find in other fonts</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.zh-TW.xlf
+++ b/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.zh-TW.xlf
@@ -2036,6 +2036,10 @@ If an ideograph has multiple entries, it means that the ideograph has multiple d
           <source>Choose existing</source>
           <target state="new">Choose existing</target>
         </trans-unit>
+        <trans-unit id="FindCharButton.Text" translate="yes" xml:space="preserve">
+          <source>Find in other fonts</source>
+          <target state="new">Find in other fonts</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/CharacterMap/CharacterMap/Provider/SQLiteGlyphProvider.cs
+++ b/CharacterMap/CharacterMap/Provider/SQLiteGlyphProvider.cs
@@ -147,11 +147,18 @@ public partial class SQLiteGlyphProvider : IGlyphDataProvider
              * Step 3: Perform LIKE search if still space for results
              */
 
+          
+
             // 1. Decide if hex or FTS4 search
-            // 1.1. If hex, search the main table (UnicodeIndex column is indexed)
+            //    If hex, search the main table (UnicodeIndex column is indexed)
             GlyphDescription hexResult = null;
+
+            // 1.1 If single Char, try forcing as hex search
+            if (query.Length == 1)
+                query = ((uint)query[0]).ToString("x4");
+
             bool ambiguous = !variant.DirectWriteProperties.IsSymbolFont && IsAmbiguousQuery(query);
-            if (Utils.TryParseHexString(query, out int hex))
+            if (hexResult == null && Utils.TryParseHexString(query, out int hex))
             {
                 // 1.2. To be more efficient, first check if the font actually contains the UnicodeIndex.
                 //      If it does then we ask the database, otherwise we can return without query.

--- a/CharacterMap/CharacterMap/Strings/en-US/Resources.resw
+++ b/CharacterMap/CharacterMap/Strings/en-US/Resources.resw
@@ -1622,4 +1622,7 @@ If an ideograph has multiple entries, it means that the ideograph has multiple d
   <data name="CollectionSelector.PlaceholderText" xml:space="preserve">
     <value>Choose existing</value>
   </data>
+  <data name="FindCharButton.Text" xml:space="preserve">
+    <value>Find in other fonts</value>
+  </data>
 </root>

--- a/CharacterMap/CharacterMap/Styles/ComboBox.xaml
+++ b/CharacterMap/CharacterMap/Styles/ComboBox.xaml
@@ -628,6 +628,9 @@
                             IsHitTestVisible="False" />
 
                         <Popup x:Name="Popup">
+                            <Popup.RenderTransform>
+                                <CompositeTransform x:Name="PopupTransform" />
+                            </Popup.RenderTransform>
                             <Border
                                 x:Name="PopupBorder"
                                 Margin="0,-1,0,-1"

--- a/CharacterMap/CharacterMap/Themes/FluentThemeStyles.xaml
+++ b/CharacterMap/CharacterMap/Themes/FluentThemeStyles.xaml
@@ -1879,6 +1879,49 @@
             <Setter.Value>
                 <ControlTemplate TargetType="AutoSuggestBox">
                     <Grid x:Name="LayoutRoot">
+                        <VisualStateManager.VisualStateGroups>
+                            <VisualStateGroup x:Name="DropDownStates">
+                                <VisualStateGroup.Transitions>
+                                    <VisualTransition From="*" To="Opened">
+                                        <Storyboard>
+                                            <!--<ObjectAnimationUsingKeyFrames Storyboard.TargetName="TextBox" Storyboard.TargetProperty="CornerRadius">
+                                                <DiscreteObjectKeyFrame KeyTime="0" Value="4 4 4 0" />
+                                            </ObjectAnimationUsingKeyFrames>-->
+                                            <DoubleAnimation
+                                                Storyboard.TargetName="SuggestionsPopup"
+                                                Storyboard.TargetProperty="Opacity"
+                                                From="0"
+                                                To="1"
+                                                Duration="0:0:0.1">
+                                                <DoubleAnimation.EasingFunction>
+                                                    <CircleEase EasingMode="EaseOut" />
+                                                </DoubleAnimation.EasingFunction>
+                                            </DoubleAnimation>
+                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="PopupTransform" Storyboard.TargetProperty="TranslateY">
+                                                <SplineDoubleKeyFrame KeyTime="0" Value="-160" />
+                                                <SplineDoubleKeyFrame KeySpline="0.1 0.9 0.2 1" KeyTime="0:0:0.3" Value="0" />
+                                            </DoubleAnimationUsingKeyFrames>
+                                        </Storyboard>
+                                    </VisualTransition>
+                                </VisualStateGroup.Transitions>
+                                <VisualState x:Name="Opened">
+                                    <!--<Storyboard>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="TextBox" Storyboard.TargetProperty="CornerRadius">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="4 4 4 0" />
+                                        </ObjectAnimationUsingKeyFrames>
+                                    </Storyboard>-->
+                                </VisualState>
+                                <VisualState x:Name="Closed">
+                                    <!--<Storyboard>
+                                        <SplitCloseThemeAnimation
+                                            ClosedTargetName="ContentPresenter"
+                                            OffsetFromCenter="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.DropDownOffset}"
+                                            OpenedLength="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.DropDownOpenedHeight}"
+                                            OpenedTargetName="SuggestionsContainer" />
+                                    </Storyboard>-->
+                                </VisualState>
+                            </VisualStateGroup>
+                        </VisualStateManager.VisualStateGroups>
                         <TextBox
                             x:Name="TextBox"
                             Width="{TemplateBinding Width}"
@@ -1898,51 +1941,58 @@
                             Style="{TemplateBinding TextBoxStyle}"
                             UseSystemFocusVisuals="{TemplateBinding UseSystemFocusVisuals}" />
 
-                        <Popup x:Name="SuggestionsPopup">
-                            <Border
-                                x:Name="SuggestionsContainer"
-                                Padding="{ThemeResource AutoSuggestListMargin}"
-                                Background="{ThemeResource AutoSuggestBoxSuggestionsListBackground}"
-                                BorderBrush="{ThemeResource AutoSuggestBoxSuggestionsListBorderBrush}"
-                                BorderThickness="{ThemeResource AutoSuggestListBorderThemeThickness}"
-                                CornerRadius="{ThemeResource OverlayCornerRadius}">
-                                <ListView
-                                    x:Name="SuggestionsList"
-                                    MaxHeight="{TemplateBinding MaxSuggestionListHeight}"
-                                    Margin="{ThemeResource AutoSuggestListPadding}"
-                                    DisplayMemberPath="{TemplateBinding DisplayMemberPath}"
-                                    Footer="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=(core:Properties.Footer)}"
-                                    IsItemClickEnabled="True"
-                                    ItemContainerStyle="{TemplateBinding ItemContainerStyle}"
-                                    ItemTemplate="{TemplateBinding ItemTemplate}"
-                                    ItemTemplateSelector="{TemplateBinding ItemTemplateSelector}">
-                                    <ListView.GroupStyle>
-                                        <GroupStyle HidesIfEmpty="True">
-                                            <GroupStyle.HeaderContainerStyle>
-                                                <Style TargetType="ListViewHeaderItem">
-                                                    <Setter Property="Padding" Value="12 12 0 4" />
-                                                    <Setter Property="Margin" Value="0" />
-                                                    <Setter Property="MinHeight" Value="0" />
-                                                    <Setter Property="BorderBrush" Value="Transparent" />
-                                                    <Setter Property="Template">
-                                                        <Setter.Value>
-                                                            <ControlTemplate TargetType="ListViewHeaderItem">
-                                                                <ContentPresenter
-                                                                    Margin="{TemplateBinding Padding}"
-                                                                    Content="{TemplateBinding Content}"
-                                                                    ContentTemplate="{TemplateBinding ContentTemplate}"
-                                                                    FontSize="12"
-                                                                    FontWeight="SemiBold"
-                                                                    Opacity="0.6"
-                                                                    Visibility="{Binding Path=Content.Key, Converter={StaticResource VisConverter}, RelativeSource={RelativeSource Mode=TemplatedParent}, FallbackValue=Collapsed, TargetNullValue=Collapsed}" />
-                                                            </ControlTemplate>
-                                                        </Setter.Value>
-                                                    </Setter>
-                                                </Style>
-                                            </GroupStyle.HeaderContainerStyle>
-                                        </GroupStyle>
-                                    </ListView.GroupStyle>
-                                </ListView>
+                        <Popup x:Name="SuggestionsPopup" Grid.ColumnSpan="2">
+                            <Border core:Properties.ClipToBounds="true">
+                                <Border
+                                    x:Name="SuggestionsContainer"
+                                    Padding="{ThemeResource AutoSuggestListMargin}"
+                                    Background="{ThemeResource AutoSuggestBoxSuggestionsListBackground}"
+                                    BorderBrush="{ThemeResource AutoSuggestBoxSuggestionsListBorderBrush}"
+                                    BorderThickness="{ThemeResource AutoSuggestListBorderThemeThickness}"
+                                    CornerRadius="0 0 8 8">
+                                    <Border.RenderTransform>
+                                        <CompositeTransform x:Name="PopupTransform" />
+                                    </Border.RenderTransform>
+                                    <ListView
+                                        x:Name="SuggestionsList"
+                                        MaxHeight="{TemplateBinding MaxSuggestionListHeight}"
+                                        Margin="{ThemeResource AutoSuggestListPadding}"
+                                        DisplayMemberPath="{TemplateBinding DisplayMemberPath}"
+                                        Footer="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=(core:Properties.Footer)}"
+                                        IsItemClickEnabled="True"
+                                        ItemContainerStyle="{TemplateBinding ItemContainerStyle}"
+                                        ItemContainerTransitions="{StaticResource NoTransitions}"
+                                        ItemTemplate="{TemplateBinding ItemTemplate}"
+                                        ItemTemplateSelector="{TemplateBinding ItemTemplateSelector}">
+                                        <ListView.GroupStyle>
+                                            <GroupStyle HidesIfEmpty="True">
+                                                <GroupStyle.HeaderContainerStyle>
+                                                    <Style TargetType="ListViewHeaderItem">
+                                                        <Setter Property="Padding" Value="12 12 0 4" />
+                                                        <Setter Property="Margin" Value="0" />
+                                                        <Setter Property="MinHeight" Value="0" />
+                                                        <Setter Property="BorderBrush" Value="Transparent" />
+                                                        <Setter Property="Template">
+                                                            <Setter.Value>
+                                                                <ControlTemplate TargetType="ListViewHeaderItem">
+                                                                    <ContentPresenter
+                                                                        Margin="{TemplateBinding Padding}"
+                                                                        Content="{TemplateBinding Content}"
+                                                                        ContentTemplate="{TemplateBinding ContentTemplate}"
+                                                                        FontSize="12"
+                                                                        FontWeight="SemiBold"
+                                                                        Opacity="0.6"
+                                                                        Visibility="{Binding Path=Content.Key, Converter={StaticResource VisConverter}, RelativeSource={RelativeSource Mode=TemplatedParent}, FallbackValue=Collapsed, TargetNullValue=Collapsed}" />
+                                                                </ControlTemplate>
+                                                            </Setter.Value>
+                                                        </Setter>
+                                                    </Style>
+                                                </GroupStyle.HeaderContainerStyle>
+                                            </GroupStyle>
+                                        </ListView.GroupStyle>
+                                    </ListView>
+                                </Border>
+
                             </Border>
                         </Popup>
                     </Grid>

--- a/CharacterMap/CharacterMap/ViewModels/MainViewModel.cs
+++ b/CharacterMap/CharacterMap/ViewModels/MainViewModel.cs
@@ -10,9 +10,9 @@ public partial class MainViewModel : ViewModelBase
 {
     public event EventHandler FontListCreated;
 
-    private Debouncer _searchDebouncer { get; } = new Debouncer();
+    private Debouncer _searchDebouncer { get; } = new ();
 
-    private Debouncer _settingsDebouncer { get; } = new Debouncer();
+    private Debouncer _settingsDebouncer { get; } = new ();
 
     private Exception _startUpException = null;
 

--- a/CharacterMap/CharacterMap/ViewModels/MainViewModel.cs
+++ b/CharacterMap/CharacterMap/ViewModels/MainViewModel.cs
@@ -2,6 +2,7 @@
 using CharacterMap.Views;
 using CommunityToolkit.Mvvm.Input;
 using System.Collections.Specialized;
+using System.Runtime.ConstrainedExecution;
 using Windows.ApplicationModel.Core;
 
 namespace CharacterMap.ViewModels;
@@ -240,9 +241,24 @@ public partial class MainViewModel : ViewModelBase
 
             if (!string.IsNullOrWhiteSpace(FontSearch))
             {
-                fontList = fontList.Where(f => f.Name.Contains(FontSearch, StringComparison.OrdinalIgnoreCase));
-                string prefix = FontListFilter == BasicFontFilter.All ? "" : FontListFilter.FilterTitle + " ";
-                FilterTitle = $"{(collection != null ? collection.Name + " " : prefix)}\"{FontSearch}\"";
+                if (FontSearch.StartsWith("char:", StringComparison.OrdinalIgnoreCase)
+                    && FontSearch.Remove(0, 5).Trim() is string q
+                    && !string.IsNullOrWhiteSpace(q))
+                {
+                    foreach (var ch in q)
+                    {
+                        if (ch == ' ')
+                            continue;
+                        fontList = BasicFontFilter.ForChar(new(ch)).Query(fontList, FontCollections);
+                    }
+                    FilterTitle = $"{FontListFilter.FilterTitle} \"{q}\"";
+                }
+                else
+                {
+                    fontList = fontList.Where(f => f.Name.Contains(FontSearch, StringComparison.OrdinalIgnoreCase));
+                    string prefix = FontListFilter == BasicFontFilter.All ? "" : FontListFilter.FilterTitle + " ";
+                    FilterTitle = $"{(collection != null ? collection.Name + " " : prefix)}\"{FontSearch}\"";
+                }
                 IsSearchResults = true;
             }
             else

--- a/CharacterMap/CharacterMap/ViewModels/SettingsViewModel.cs
+++ b/CharacterMap/CharacterMap/ViewModels/SettingsViewModel.cs
@@ -114,7 +114,10 @@ public partial class SettingsViewModel : ViewModelBase
         // application, rather than things like bug-fixes or visual changes.
         return new()
         {
-             new("Latest Update (November 2023)", // August 2023
+            new("Latest Update (December 2023)", // Dec 2023
+                "- Support search for fonts that contain specific characters in \"Find a font family\" search box, by typing in \"char:\" followed by your query.\n" +
+                "    • e.g. to find all fonts that contain the two arrow characters '←' & '↗', type in \"char: ←↗\""),
+             new("2023.9.0.0 (November 2023)", // Nov 2023
                 "- Integrate the Unicode Unihan readings data set, providing descriptions and pronunciations for CJK Han ideographs\n" +
                 "- Added support for installing opened .WOFF & .WOFF2 fonts\n" +
                 "- Added support for showing Design Script Languages in Font Properties flyout\n" +

--- a/CharacterMap/CharacterMap/ViewModels/SettingsViewModel.cs
+++ b/CharacterMap/CharacterMap/ViewModels/SettingsViewModel.cs
@@ -116,7 +116,8 @@ public partial class SettingsViewModel : ViewModelBase
         {
             new("Latest Update (December 2023)", // Dec 2023
                 "- Support search for fonts that contain specific characters in \"Find a font family\" search box, by typing in \"char:\" followed by your query.\n" +
-                "    • e.g. to find all fonts that contain the two arrow characters '←' & '↗', type in \"char: ←↗\""),
+                "    • e.g. to find all fonts that contain the two arrow characters '←' & '↗', type in \"char: ←↗\"\n" +
+                "- Added option to search for other fonts with the selected character in context menu of main window's Character Map"),
              new("2023.9.0.0 (November 2023)", // Nov 2023
                 "- Integrate the Unicode Unihan readings data set, providing descriptions and pronunciations for CJK Han ideographs\n" +
                 "- Added support for installing opened .WOFF & .WOFF2 fonts\n" +

--- a/CharacterMap/CharacterMap/Views/FontMapView.xaml
+++ b/CharacterMap/CharacterMap/Views/FontMapView.xaml
@@ -304,7 +304,18 @@
                 Click="AddClick"
                 Icon="Add"
                 Style="{StaticResource ThemeMenuFlyoutItemStyle}" />
+
             <MenuFlyoutSeparator />
+
+            <MenuFlyoutItem
+                x:Name="FindCharButton"
+                x:Uid="FindCharButton"
+                Click="FindClick"
+                Icon="Find"
+                Style="{StaticResource ThemeMenuFlyoutItemStyle}"
+                d:Text="Find in other fonts SAMPLE" />
+
+            <MenuFlyoutSeparator Visibility="{Binding ElementName=FindCharButton, Path=Visibility}" />
 
             <MenuFlyoutItem
                 x:Uid="CalligraphyLabel"

--- a/CharacterMap/CharacterMap/Views/FontMapView.xaml
+++ b/CharacterMap/CharacterMap/Views/FontMapView.xaml
@@ -1403,26 +1403,6 @@
                         RenderingOptions="{x:Bind ViewModel.RenderingOptions, Mode=OneWay}"
                         Text="{Binding TypeRampText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
 
-                    <controls:FlowAwareComboBox
-                        x:Name="TypeRampInputBox"
-                        x:Uid="TypeRampInputBox"
-                        MinWidth="430"
-                        MinHeight="0"
-                        Margin="12 12 0 12"
-                        HorizontalAlignment="Left"
-                        core:Properties.PointerOverAnimation="DropDownGlyph"
-                        Background="Transparent"
-                        BorderThickness="0 0 0 1"
-                        ContextFlyout="{StaticResource SuggestionFlyout}"
-                        CornerRadius="4 0 0 4"
-                        Header="Preview Text"
-                        IsColorFontEnabled="{Binding RenderingOptions.IsColourFontEnabled}"
-                        IsEditable="True"
-                        SelectedIndex="0"
-                        Style="{StaticResource RampComboBoxStyle}"
-                        Text="{Binding TypeRampText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                        Visibility="Collapsed" />
-
                     <controls:UXButton
                         x:Name="TypeRampFlowButton"
                         x:Uid="TypeRampFlowButton"
@@ -1453,7 +1433,7 @@
                     MaxHeight="246">
                     <ItemsControl
                         x:Name="VariableAxis"
-                        Margin="24 0"
+                        Margin="24 0 24 0"
                         Padding="12"
                         Background="LightGray"
                         ItemsSource="{x:Bind ViewModel.SelectedVariantAnalysis.VariableAxis, Mode=OneWay}">
@@ -1518,7 +1498,7 @@
                         ItemsSource="{x:Bind ViewModel.Ramps, Mode=OneWay}">
                         <ItemsControl.ItemsPanel>
                             <ItemsPanelTemplate>
-                                <StackPanel Margin="22 10 6 48" Spacing="16" />
+                                <StackPanel Margin="24 10 6 48" Spacing="16" />
                             </ItemsPanelTemplate>
                         </ItemsControl.ItemsPanel>
                         <ItemsControl.ItemTemplate>

--- a/CharacterMap/CharacterMap/Views/FontMapView.xaml.cs
+++ b/CharacterMap/CharacterMap/Views/FontMapView.xaml.cs
@@ -664,7 +664,6 @@ public sealed partial class FontMapView : ViewBase, IInAppNotificationPresenter,
     private void UserControl_SizeChanged(object sender, SizeChangedEventArgs e)
     {
         // Make sure the PreviewColumn fits properly.
-
         if (e.NewSize.Width > e.PreviousSize.Width)
             return;
 
@@ -673,6 +672,7 @@ public sealed partial class FontMapView : ViewBase, IInAppNotificationPresenter,
             if (!this.IsLoaded)
                 return;
 
+            // Make sure PreviewColumn stays at a workable size
             if (CharGrid.Visibility == Visibility.Visible)
             {
                 int size = (int)CharGrid.ActualWidth + (int)Splitter.ActualWidth + (int)PreviewGrid.ActualWidth;
@@ -861,7 +861,7 @@ public sealed partial class FontMapView : ViewBase, IInAppNotificationPresenter,
         {
             /* Context menu for character grid */
             args.Handled = true;
-            FlyoutHelper.ShowCharacterGridContext(GridContextFlyout, grid, ViewModel);
+            FlyoutHelper.ShowCharacterGridContext(GridContextFlyout, grid, ViewModel, IsStandalone);
         }
     }
 
@@ -1025,6 +1025,14 @@ public sealed partial class FontMapView : ViewBase, IInAppNotificationPresenter,
     private void FilterHint_Click(object sender, RoutedEventArgs e)
     {
         CharacterFilterButton.Focus(FocusState.Keyboard);
+    }
+
+    private void FindClick(object sender, RoutedEventArgs e)
+    {
+        if (sender is MenuFlyoutItem { DataContext: Character c }
+            && this.IsStandalone == false
+            && this.GetFirstAncestorOfType<MainPage>() is { } m)
+            m.CharacterSearch(c.Char);
     }
 
 

--- a/CharacterMap/CharacterMap/Views/FontMapView.xaml.cs
+++ b/CharacterMap/CharacterMap/Views/FontMapView.xaml.cs
@@ -25,9 +25,7 @@ public sealed partial class FontMapView : ViewBase, IInAppNotificationPresenter,
         set { SetValue(TitleLeftContentProperty, value); }
     }
 
-    // Using a DependencyProperty as the backing store for TitleLeftContent.  This enables animation, styling, binding, etc...
-    public static readonly DependencyProperty TitleLeftContentProperty =
-        DependencyProperty.Register(nameof(TitleLeftContent), typeof(object), typeof(FontMapView), new PropertyMetadata(null));
+    public static readonly DP TitleLeftContentProperty = DP<object, FontMapView>();
 
     #endregion
 
@@ -39,9 +37,7 @@ public sealed partial class FontMapView : ViewBase, IInAppNotificationPresenter,
         set { SetValue(TitleRightContentProperty, value); }
     }
 
-    // Using a DependencyProperty as the backing store for TitleRightContent.  This enables animation, styling, binding, etc...
-    public static readonly DependencyProperty TitleRightContentProperty =
-        DependencyProperty.Register(nameof(TitleRightContent), typeof(object), typeof(FontMapView), new PropertyMetadata(null));
+    public static readonly DP TitleRightContentProperty = DP<object, FontMapView>();
 
     #endregion
 
@@ -53,12 +49,11 @@ public sealed partial class FontMapView : ViewBase, IInAppNotificationPresenter,
         set => SetValue(FontProperty, value);
     }
 
-    public static readonly DependencyProperty FontProperty =
-        DependencyProperty.Register(nameof(Font), typeof(FontItem), typeof(FontMapView), new PropertyMetadata(null, (d, e) =>
-        {
-            if (d is FontMapView f && e.NewValue is FontItem item)
-                f.ViewModel.SelectedFont = item;
-        }));
+    public static readonly DP FontProperty = DP<FontItem, FontMapView>(null, (d, o, n) =>
+    {
+        if (n is not null)
+            d.ViewModel.SelectedFont = n;
+    });
 
     #endregion
 
@@ -70,8 +65,7 @@ public sealed partial class FontMapView : ViewBase, IInAppNotificationPresenter,
         private set => SetValue(ViewModelProperty, value);
     }
 
-    public static readonly DependencyProperty ViewModelProperty =
-        DependencyProperty.Register(nameof(ViewModel), typeof(FontMapViewModel), typeof(FontMapView), new PropertyMetadata(null));
+    public static readonly DP ViewModelProperty = DP<FontMapViewModel, FontMapView>();
 
     #endregion
 
@@ -83,8 +77,7 @@ public sealed partial class FontMapView : ViewBase, IInAppNotificationPresenter,
         set { SetValue(HideTitleProperty, value); }
     }
 
-    public static readonly DependencyProperty HideTitleProperty =
-        DependencyProperty.Register(nameof(HideTitle), typeof(bool), typeof(FontMapView), new PropertyMetadata(false));
+    public static readonly DP HideTitleProperty = DP<bool, FontMapView>();
 
     #endregion
 

--- a/CharacterMap/CharacterMap/Views/MainPage.xaml.cs
+++ b/CharacterMap/CharacterMap/Views/MainPage.xaml.cs
@@ -115,7 +115,7 @@ public sealed partial class MainPage : ViewBase, IInAppNotificationPresenter, IP
 
     bool _disableMapChange = true;
 
-    private void ViewModel_PropertyChanged(object sender, PropertyChangedEventArgs e)
+    void ViewModel_PropertyChanged(object sender, PropertyChangedEventArgs e)
     {
         switch (e.PropertyName)
         {
@@ -181,7 +181,7 @@ public sealed partial class MainPage : ViewBase, IInAppNotificationPresenter, IP
         }
     }
 
-    private void OnAppSettingsChanged(AppSettingsChangedMessage msg)
+    void OnAppSettingsChanged(AppSettingsChangedMessage msg)
     {
         switch (msg.PropertyName)
         {
@@ -228,7 +228,7 @@ public sealed partial class MainPage : ViewBase, IInAppNotificationPresenter, IP
         ViewModel.FontListCreated -= ViewModel_FontListCreated;
     }
 
-    private void MainPage_SizeChanged(object sender, SizeChangedEventArgs e)
+    void MainPage_SizeChanged(object sender, SizeChangedEventArgs e)
     {
         if (e.NewSize.Width < 900)
             GoToState(nameof(CompactViewState));
@@ -241,7 +241,7 @@ public sealed partial class MainPage : ViewBase, IInAppNotificationPresenter, IP
             GoToState(nameof(WindowState));
     }
 
-    private void OnColorValuesChanged(UISettings settings, object e)
+    void OnColorValuesChanged(UISettings settings, object e)
     {
         RunOnUI(() =>
         {
@@ -250,7 +250,7 @@ public sealed partial class MainPage : ViewBase, IInAppNotificationPresenter, IP
         });
     }
 
-    private void OnAnimationsEnabledChanged(UISettings sender, UISettingsAnimationsEnabledChangedEventArgs args)
+    void OnAnimationsEnabledChanged(UISettings sender, UISettingsAnimationsEnabledChangedEventArgs args)
     {
         RunOnUI(() =>
         {
@@ -260,7 +260,7 @@ public sealed partial class MainPage : ViewBase, IInAppNotificationPresenter, IP
         });
     }
 
-    private void UpdateLoadingStates()
+    void UpdateLoadingStates()
     {
         TitleBar.TryUpdateMetrics();
 
@@ -296,7 +296,7 @@ public sealed partial class MainPage : ViewBase, IInAppNotificationPresenter, IP
         }
     }
 
-    private void ViewModel_FontListCreated(object sender, EventArgs e)
+    void ViewModel_FontListCreated(object sender, EventArgs e)
     {
         StartScrollSelectedIntoView();
     }
@@ -320,7 +320,7 @@ public sealed partial class MainPage : ViewBase, IInAppNotificationPresenter, IP
         });
     }
 
-    private void TogglePane_Click(object sender, RoutedEventArgs e)
+    void TogglePane_Click(object sender, RoutedEventArgs e)
     {
         if (SplitView.DisplayMode == SplitViewDisplayMode.Inline)
             GoToState(nameof(CollapsedViewState));
@@ -342,24 +342,24 @@ public sealed partial class MainPage : ViewBase, IInAppNotificationPresenter, IP
             LstFontFamily.SelectedItem = null;
     }
 
-    private void FontMapContainer_AddTabButtonClick(TabView sender, object args)
+    void FontMapContainer_AddTabButtonClick(TabView sender, object args)
     {
         ViewModel.Fonts.Add(new(ViewModel.SelectedFont));
         FontsTabBar.SelectedIndex = ViewModel.Fonts.Count - 1;
     }
 
-    private void FontMapContainer_TabCloseRequested(TabView sender, TabViewTabCloseRequestedEventArgs args)
+    void FontMapContainer_TabCloseRequested(TabView sender, TabViewTabCloseRequestedEventArgs args)
     {
         ViewModel.TryCloseTab(sender.TabItems.IndexOf(args.Item));
     }
 
-    private void TabViewItem_DoubleTapped(object sender, DoubleTappedRoutedEventArgs e)
+    void TabViewItem_DoubleTapped(object sender, DoubleTappedRoutedEventArgs e)
     {
         if (sender is FrameworkElement f && f.DataContext is FontItem item)
             ViewModel.TryCloseTab(FontsTabBar.TabItems.IndexOf(item));
     }
 
-    private void BtnSettings_OnClick(object sender, RoutedEventArgs e)
+    void BtnSettings_OnClick(object sender, RoutedEventArgs e)
     {
         ShowSettings();
     }
@@ -425,13 +425,13 @@ public sealed partial class MainPage : ViewBase, IInAppNotificationPresenter, IP
     }
 
 
-    private bool AreModalsOpen()
+    bool AreModalsOpen()
     {
         return (SettingsView != null && SettingsView.IsOpen)
                  || (PrintPresenter != null && PrintPresenter.Child != null);
     }
 
-    private void LayoutRoot_KeyDown(object sender, KeyRoutedEventArgs e)
+    void LayoutRoot_KeyDown(object sender, KeyRoutedEventArgs e)
     {
         if (e.Key == VirtualKey.F11)
             Utils.ToggleFullScreenMode();
@@ -465,7 +465,7 @@ public sealed partial class MainPage : ViewBase, IInAppNotificationPresenter, IP
         }
     }
 
-    private void FontsTabBar_Loaded(object sender, RoutedEventArgs e)
+    void FontsTabBar_Loaded(object sender, RoutedEventArgs e)
     {
         // 1. Ensure animations are correct
         UpdateAnimation();
@@ -528,7 +528,7 @@ public sealed partial class MainPage : ViewBase, IInAppNotificationPresenter, IP
         _ = QuickCompareView.CreateWindowAsync(new(false, new(variants)));
     }
 
-    private void LstFontFamily_SelectionChanged(object sender, SelectionChangedEventArgs e)
+    void LstFontFamily_SelectionChanged(object sender, SelectionChangedEventArgs e)
     {
         if (ViewModel.IsLoadingFonts is false &&
             e.AddedItems.FirstOrDefault() is InstalledFont font)
@@ -537,7 +537,7 @@ public sealed partial class MainPage : ViewBase, IInAppNotificationPresenter, IP
         }
     }
 
-    private void OpenFontPaneButton_Click(object sender, RoutedEventArgs e)
+    void OpenFontPaneButton_Click(object sender, RoutedEventArgs e)
     {
         SplitView.IsPaneOpen = !SplitView.IsPaneOpen;
     }
@@ -553,7 +553,7 @@ public sealed partial class MainPage : ViewBase, IInAppNotificationPresenter, IP
         }
     }
 
-    private string UpdateFontCountLabel(List<InstalledFont> fontList, bool keepCasing)
+    string UpdateFontCountLabel(List<InstalledFont> fontList, bool keepCasing)
     {
         if (fontList != null)
         {
@@ -570,7 +570,7 @@ public sealed partial class MainPage : ViewBase, IInAppNotificationPresenter, IP
         return string.Empty;
     }
 
-    private void OnFilterClick(object parameter)
+    void OnFilterClick(object parameter)
     {
         if (parameter is BasicFontFilter filter)
         {
@@ -584,7 +584,7 @@ public sealed partial class MainPage : ViewBase, IInAppNotificationPresenter, IP
         }
     }
 
-    private void OnFontPreviewUpdated()
+    void OnFontPreviewUpdated()
     {
         if (ViewModel.InitialLoad.IsCompleted)
         {
@@ -604,19 +604,19 @@ public sealed partial class MainPage : ViewBase, IInAppNotificationPresenter, IP
         }
     }
 
-    private void FontCompareButton_Click(object sender, RoutedEventArgs e)
+    void FontCompareButton_Click(object sender, RoutedEventArgs e)
     {
         DismissMenu();
 
         _ = QuickCompareView.CreateWindowAsync(new(false, ViewModel.Folder));
     }
 
-    private void CollectionCompareButton_Click(object sender, RoutedEventArgs e)
+    void CollectionCompareButton_Click(object sender, RoutedEventArgs e)
     {
         _ = QuickCompareView.CreateWindowAsync(new(false) { SelectedCollection = ViewModel.SelectedCollection });
     }
 
-    private void LstFontFamily_ContainerContentChanging(ListViewBase sender, ContainerContentChangingEventArgs args)
+    void LstFontFamily_ContainerContentChanging(ListViewBase sender, ContainerContentChangingEventArgs args)
     {
         args.ItemContainer.PointerPressed -= ItemContainer_PointerPressed;
         args.ItemContainer.PointerPressed += ItemContainer_PointerPressed;
@@ -625,7 +625,7 @@ public sealed partial class MainPage : ViewBase, IInAppNotificationPresenter, IP
         args.ItemContainer.ContextRequested += ItemContainer_ContextRequested;
     }
 
-    private void ItemContainer_PointerPressed(object sender, PointerRoutedEventArgs e)
+    void ItemContainer_PointerPressed(object sender, PointerRoutedEventArgs e)
     {
         /* MIDDLE CLICK FOR FONT LIST */
         var pointer = e.GetCurrentPoint(sender as FrameworkElement);
@@ -647,7 +647,7 @@ public sealed partial class MainPage : ViewBase, IInAppNotificationPresenter, IP
         }
     }
 
-    private void ItemContainer_ContextRequested(UIElement sender, ContextRequestedEventArgs args)
+    void ItemContainer_ContextRequested(UIElement sender, ContextRequestedEventArgs args)
     {
         /* RIGHT CLICK MENU FOR FONT LIST */
         if (sender is ListViewItem f && f.Content is InstalledFont font)
@@ -671,7 +671,7 @@ public sealed partial class MainPage : ViewBase, IInAppNotificationPresenter, IP
         }
     }
 
-    private void TabViewItemContext_Opening(object sender, object e)
+    void TabViewItemContext_Opening(object sender, object e)
     {
         if (sender is MenuFlyout menu && menu.Target is TabViewItem t && t.DataContext is FontItem item)
         {
@@ -689,6 +689,20 @@ public sealed partial class MainPage : ViewBase, IInAppNotificationPresenter, IP
                     PreviewText = FontMap.ViewModel.Sequence
                 });
         }
+    }
+
+    void OpenFolder()
+    {
+        DismissMenu();
+        _ = (new OpenFolderDialog()).ShowAsync();
+    }
+
+    void DismissMenu() => AppMenuFlyout.Hide();
+
+    public void CharacterSearch(string s)
+    {
+        ViewModel.FontSearch = $"char: {s}";
+        FontListSearchBox.Focus(FocusState.Keyboard);
     }
 
     public void ShowEditSuggestions()
@@ -709,25 +723,17 @@ public sealed partial class MainPage : ViewBase, IInAppNotificationPresenter, IP
         });
     }
 
-    private void OpenFolder()
-    {
-        DismissMenu();
-        _ = (new OpenFolderDialog()).ShowAsync();
-    }
-
-    void DismissMenu() => AppMenuFlyout.Hide();
-
 
 
 
     /* Font Collection management */
 
-    private void RenameFontCollection_Click(object sender, RoutedEventArgs e)
+    void RenameFontCollection_Click(object sender, RoutedEventArgs e)
     {
         _ = (new CreateCollectionDialog(ViewModel.SelectedCollection)).ShowAsync();
     }
 
-    private void DeleteCollection_Click(object sender, RoutedEventArgs e)
+    void DeleteCollection_Click(object sender, RoutedEventArgs e)
     {
         ContentDialog d = new()
         {
@@ -742,7 +748,7 @@ public sealed partial class MainPage : ViewBase, IInAppNotificationPresenter, IP
         _ = d.ShowAsync();
     }
 
-    private async void DigDeleteCollection_PrimaryButtonClick(ContentDialog sender, ContentDialogButtonClickEventArgs args)
+    async void DigDeleteCollection_PrimaryButtonClick(ContentDialog sender, ContentDialogButtonClickEventArgs args)
     {
         string name = ViewModel.SelectedCollection.Name;
         await ViewModel.FontCollections.DeleteCollectionAsync(ViewModel.SelectedCollection);
@@ -756,13 +762,13 @@ public sealed partial class MainPage : ViewBase, IInAppNotificationPresenter, IP
 
     /* Drag / Drop support */
 
-    private void Grid_DragOver(object sender, DragEventArgs e)
+    void Grid_DragOver(object sender, DragEventArgs e)
     {
         if (e.DataView.Contains(StandardDataFormats.StorageItems))
             e.AcceptedOperation = DataPackageOperation.Copy;
     }
 
-    private async void Grid_Drop(object sender, DragEventArgs e)
+    async void Grid_Drop(object sender, DragEventArgs e)
     {
         if (e.DataView.Contains(StandardDataFormats.StorageItems))
         {
@@ -790,7 +796,7 @@ public sealed partial class MainPage : ViewBase, IInAppNotificationPresenter, IP
         }
     }
 
-    private async void OpenFont()
+    async void OpenFont()
     {
         DismissMenu();
 
@@ -828,7 +834,7 @@ public sealed partial class MainPage : ViewBase, IInAppNotificationPresenter, IP
         }
     }
 
-    private void OnFontImportRequest(ImportMessage msg)
+    void OnFontImportRequest(ImportMessage msg)
     {
         _ = CoreApplication.MainView.Dispatcher.RunAsync(CoreDispatcherPriority.Normal, async () =>
         {
@@ -927,17 +933,17 @@ public sealed partial class MainPage : ViewBase, IInAppNotificationPresenter, IP
 
     /* Composition & Animation */
 
-    private void Grid_Loading(FrameworkElement sender, object args)
+    void Grid_Loading(FrameworkElement sender, object args)
     {
         CompositionFactory.SetThemeShadow(sender, 40, PaneRoot);
     }
 
-    private void FontListGrid_Loading(FrameworkElement sender, object args)
+    void FontListGrid_Loading(FrameworkElement sender, object args)
     {
         UpdateCollectionRowAnimation();
     }
 
-    private void UpdateAnimation()
+    void UpdateAnimation()
     {
         UpdateCollectionRowAnimation();
 
@@ -961,7 +967,7 @@ public sealed partial class MainPage : ViewBase, IInAppNotificationPresenter, IP
             CollectionControlRow);
     }
 
-    private void LoadingRoot_Loading(FrameworkElement sender, object args)
+    void LoadingRoot_Loading(FrameworkElement sender, object args)
     {
         if (ResourceHelper.AllowAnimation is false)
             return;


### PR DESCRIPTION
## New Features

- Support single char searches. Can paste a single char into the search box, and by tapping search result you are brought to that character, making it easier to find a character inside large fonts

<img width="387" alt="image" src="https://github.com/character-map-uwp/Character-Map-UWP/assets/2319473/2651d16f-1e12-4ebc-9273-f430801e3076">

- Support searching for all fonts that contain a character using `char: {0}` search syntax. For example to find all fonts containing `嘉` I would search `char: 嘉` in the Font list search box

<img width="207" alt="image" src="https://github.com/character-map-uwp/Character-Map-UWP/assets/2319473/1769d3f4-fcb5-4dbc-b063-7f6fff1dc4e0">

- Added a context menu item to char grid that will perform this search automatically
<img width="222" alt="image" src="https://github.com/character-map-uwp/Character-Map-UWP/assets/2319473/799b6352-d975-461c-baf0-d68dfe4d868a">

