### PR TITLE
Update pt-PT translation

### DIFF
--- a/CharacterMap/CharacterMap/CharacterMap.csproj
+++ b/CharacterMap/CharacterMap/CharacterMap.csproj
@@ -168,9 +168,6 @@
     <!-- A reference to the entire .Net Framework and Windows SDK are automatically included -->
     <Content Include="Assets\ColourIcon.png" />
     <Content Include="Assets\Data\GlyphData.db" />
-    <PRIResource Include="Strings\zh-TW\Resources.resw" />
-    <PRIResource Include="Strings\zh-CN\Resources.resw" />
-    <PRIResource Include="Strings\en-US\Resources.resw" />
   </ItemGroup>
   <ItemGroup Condition="'$(Configuration)' == 'Debug'">
     <Content Include="Assets\Data\glyphlist.txt" />
@@ -465,12 +462,16 @@
     <Content Include="Assets\Square44x44Logo.targetsize-24_altform-unplated.png" />
     <Content Include="Assets\Wide310x150Logo.scale-200.png" />
     <None Include="CharacterMap_TemporaryKey.pfx" />
+    <PRIResource Include="Strings\en-US\Resources.resw" />
+    <PRIResource Include="Strings\en-GB\Resources.resw" />
     <PRIResource Include="Strings\de-DE\Resources.resw" />
     <PRIResource Include="Strings\pl-PL\Resources.resw" />
-    <PRIResource Include="Strings\ta\Resources.resw" />
+    <PRIResource Include="Strings\pt-PT\Resources.resw" />
     <PRIResource Include="Strings\it-IT\Resources.resw" />
+    <PRIResource Include="Strings\ta\Resources.resw" />
     <PRIResource Include="Strings\th-TH\Resources.resw" />
-    <PRIResource Include="Strings\en-GB\Resources.resw" />
+    <PRIResource Include="Strings\zh-CN\Resources.resw" />
+    <PRIResource Include="Strings\zh-TW\Resources.resw" />
   </ItemGroup>
   <ItemGroup>
     <ApplicationDefinition Include="App.xaml">
@@ -614,6 +615,7 @@
     <XliffResource Include="MultilingualResources\CharacterMap.fr-FR.xlf" />
     <XliffResource Include="MultilingualResources\CharacterMap.it-IT.xlf" />
     <XliffResource Include="MultilingualResources\CharacterMap.pl-PL.xlf" />
+    <XliffResource Include="MultilingualResources\CharacterMap.pt-PT.xlf" />
     <XliffResource Include="MultilingualResources\CharacterMap.ru-RU.xlf" />
     <XliffResource Include="MultilingualResources\CharacterMap.ta.xlf" />
     <XliffResource Include="MultilingualResources\CharacterMap.th-TH.xlf" />

--- a/CharacterMap/CharacterMap/Controls/OpenFolderDialog.xaml
+++ b/CharacterMap/CharacterMap/Controls/OpenFolderDialog.xaml
@@ -47,7 +47,7 @@
 
             <TextBlock Margin="0 -8 0 0" HorizontalAlignment="Center">
                 <Run Text="{core:Localizer Key=DigOpenFolderContent/PrefixLabel}" d:Text="Found" />
-                <Run Text="{x:Bind TemplateSettings.Count, Mode=OneWay}" />
+                <Run Text="{x:Bind TemplateSettings.Count, Mode=OneWay}" d:Text="11" />
                 <Run Text="{core:Localizer Key=DigOpenFolderContent/SuffixLabel}" d:Text="font files" />
             </TextBlock>
         </StackPanel>

--- a/CharacterMap/CharacterMap/Controls/OpenFolderDialog.xaml.cs
+++ b/CharacterMap/CharacterMap/Controls/OpenFolderDialog.xaml.cs
@@ -7,7 +7,7 @@ namespace CharacterMap.Controls;
 public class OpenFolderDialogTemplateSettings : ViewModelBase
 {
     public bool CanContinue => HasFolder is true && IsLoading is false;
-    public string Contents { get => Get<string>(() => "Select Folder"); set => Set(value); }
+    public string Contents { get => Get<string>(() => Localization.Get("DigOpenFolderContent/SelectFolderButtonContent")); set => Set(value); }
     public bool HasFolder { get => GetV(false); set => Set(value); }
     public bool IsLoading { get => GetV(false); set => Set(value); }
     public bool AllowZip { get => GetV(false); set => Set(value); }
@@ -28,7 +28,7 @@ public class OpenFolderDialogTemplateSettings : ViewModelBase
         else
         {
             HasFolder = false;
-            Contents = "Select Folder";
+            Contents = Localization.Get("DigOpenFolderContent/SelectFolderButtonContent");
         }
     }
 

--- a/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.de-DE.xlf
+++ b/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.de-DE.xlf
@@ -2225,6 +2225,10 @@ Otherwise, "All Fonts" is selected by default on every launch.</target>
           <source>To modify smart collections use the edit button above.</source>
           <target state="new">To modify smart collections use the edit button above.</target>
         </trans-unit>
+        <trans-unit id="DigOpenFolderContent.SelectFolderButtonContent" translate="yes" xml:space="preserve">
+          <source>Select Folder</source>
+          <target state="translated">Ordner auswählen</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.en-GB.xlf
+++ b/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.en-GB.xlf
@@ -2224,6 +2224,10 @@ Otherwise, "All Fonts" is selected by default on every launch.</target>
           <source>To modify smart collections use the edit button above.</source>
           <target state="new">To modify smart collections use the edit button above.</target>
         </trans-unit>
+        <trans-unit id="DigOpenFolderContent.SelectFolderButtonContent" translate="yes" xml:space="preserve">
+          <source>Select Folder</source>
+          <target state="new">Select Folder</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.fr-FR.xlf
+++ b/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.fr-FR.xlf
@@ -2226,6 +2226,10 @@ Otherwise, "All Fonts" is selected by default on every launch.</target>
           <source>To modify smart collections use the edit button above.</source>
           <target state="new">To modify smart collections use the edit button above.</target>
         </trans-unit>
+        <trans-unit id="DigOpenFolderContent.SelectFolderButtonContent" translate="yes" xml:space="preserve">
+          <source>Select Folder</source>
+          <target state="translated">Sélectionner un dossier</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.it-IT.xlf
+++ b/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.it-IT.xlf
@@ -2230,6 +2230,10 @@ Otherwise, "All Fonts" is selected by default on every launch.</target>
           <source>To modify smart collections use the edit button above.</source>
           <target state="new">To modify smart collections use the edit button above.</target>
         </trans-unit>
+        <trans-unit id="DigOpenFolderContent.SelectFolderButtonContent" translate="yes" xml:space="preserve">
+          <source>Select Folder</source>
+          <target state="translated">Selezione cartella</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.pl-PL.xlf
+++ b/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.pl-PL.xlf
@@ -2228,6 +2228,10 @@ Otherwise, "All Fonts" is selected by default on every launch.</target>
           <source>To modify smart collections use the edit button above.</source>
           <target state="new">To modify smart collections use the edit button above.</target>
         </trans-unit>
+        <trans-unit id="DigOpenFolderContent.SelectFolderButtonContent" translate="yes" xml:space="preserve">
+          <source>Select Folder</source>
+          <target state="translated">Wybierz folder</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.pt-PT.xlf
+++ b/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.pt-PT.xlf
@@ -2223,6 +2223,10 @@ Caso contrário, "Todos os tipos de letra" é selecionado por predefinição em 
           <source>To modify smart collections use the edit button above.</source>
           <target state="translated">Para modificar as coleções inteligentes, utilize o botão de editar acima.</target>
         </trans-unit>
+        <trans-unit id="DigOpenFolderContent.SelectFolderButtonContent" translate="yes" xml:space="preserve">
+          <source>Select Folder</source>
+          <target state="translated">Selecionar pasta</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.pt-PT.xlf
+++ b/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.pt-PT.xlf
@@ -1,5 +1,4 @@
-  
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en-US" target-language="pt-PT" original="CHARACTERMAP/STRINGS/EN-US/RESOURCES.RESW" tool-id="MultilingualAppToolkit" product-name="n/a" product-version="n/a" build-num="n/a">
     <header>
@@ -9,19 +8,19 @@
       <group id="CHARACTERMAP/STRINGS/EN-US/RESOURCES.RESW" datatype="resx">
         <trans-unit id="AddToCollectionHint.Text" translate="yes" xml:space="preserve">
           <source>Add to Library</source>
-          <target state="translated">Adicionar à Biblioteca</target>
+          <target state="translated">Adicionar à biblioteca</target>
         </trans-unit>
         <trans-unit id="AppName" translate="yes" xml:space="preserve">
-          <source>Character Map</source>
-          <target state="translated">Mapa de Carateres</target>
+          <source>Character Map UWP</source>
+          <target state="translated">Mapa de caracteres UWP</target>
         </trans-unit>
         <trans-unit id="BlackFill.Text" translate="yes" xml:space="preserve">
           <source>Black Fill</source>
-          <target state="translated">Preenchimento Preto</target>
+          <target state="translated">Preenchimento preto</target>
         </trans-unit>
         <trans-unit id="BtnCopy.Text" translate="yes" xml:space="preserve">
           <source>Copy as text</source>
-          <target state="translated">Copiar como Texto</target>
+          <target state="translated">Copiar como texto</target>
         </trans-unit>
         <trans-unit id="BtnSelect.Content" translate="yes" xml:space="preserve">
           <source>Select</source>
@@ -29,43 +28,43 @@
         </trans-unit>
         <trans-unit id="ColoredGlyphLabel.Text" translate="yes" xml:space="preserve">
           <source>Colored Glyph</source>
-          <target state="translated">Colored Glyph</target>
+          <target state="translated">Glifo colorido</target>
         </trans-unit>
         <trans-unit id="ColorGlyphToggle.OffContent" translate="yes" xml:space="preserve">
-          <source>Monochrome glyphs</source>
-          <target state="translated">Monochrome glyphs</target>
+          <source>Monochrome Glyphs</source>
+          <target state="translated">Glifo monocromático</target>
         </trans-unit>
         <trans-unit id="ColorGlyphToggle.OnContent" translate="yes" xml:space="preserve">
           <source>Color glyphs</source>
-          <target state="translated">Color glyphs</target>
+          <target state="translated">Glifos coloridos</target>
         </trans-unit>
         <trans-unit id="FontDisplayHeader.Text" translate="yes" xml:space="preserve">
           <source>Font Display Options</source>
-          <target state="translated">Opções de Visualização da Fonte</target>
+          <target state="translated">Opções de visualização do tipo de letra</target>
         </trans-unit>
         <trans-unit id="FontOptionsButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" translate="yes" xml:space="preserve">
           <source>Font Rendering Options</source>
-          <target state="translated">Opções de Renderização da Fonte</target>
+          <target state="translated">Opções de composição do tipo de letra</target>
         </trans-unit>
         <trans-unit id="FontPropertiesButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" translate="yes" xml:space="preserve">
           <source>Font Face Properties</source>
-          <target state="translated">Propriedades do Rosto da Fonte</target>
+          <target state="translated">Propriedades do tipo de letra</target>
         </trans-unit>
         <trans-unit id="FontPropFace.Text" translate="yes" xml:space="preserve">
           <source>Face Name</source>
-          <target state="translated">Nome do Rosto</target>
+          <target state="translated">Nome da variante</target>
         </trans-unit>
         <trans-unit id="FontPropFamily.Text" translate="yes" xml:space="preserve">
           <source>Family Name</source>
-          <target state="translated">Nome da Familia</target>
+          <target state="translated">Nome da família</target>
         </trans-unit>
         <trans-unit id="FontPropMonospaced.Text" translate="yes" xml:space="preserve">
           <source>Is Monospaced</source>
-          <target state="translated">É Monoespaçado</target>
+          <target state="translated">Monoespaçada</target>
         </trans-unit>
         <trans-unit id="FontPropStretch.Text" translate="yes" xml:space="preserve">
           <source>Stretch</source>
-          <target state="translated">Esticar</target>
+          <target state="translated">Largura</target>
         </trans-unit>
         <trans-unit id="FontPropStyle.Text" translate="yes" xml:space="preserve">
           <source>Style</source>
@@ -73,11 +72,11 @@
         </trans-unit>
         <trans-unit id="FontPropSymbol.Text" translate="yes" xml:space="preserve">
           <source>Is Symbol Font</source>
-          <target state="translated">É Fonte de Símbolo</target>
+          <target state="translated">Símbolos</target>
         </trans-unit>
         <trans-unit id="FontPropTitle.Text" translate="yes" xml:space="preserve">
           <source>Font Face Properties</source>
-          <target state="translated">Propriedades do Rosto da Fonte</target>
+          <target state="translated">Propriedades do tipo de letra</target>
         </trans-unit>
         <trans-unit id="FontPropType.Text" translate="yes" xml:space="preserve">
           <source>Type</source>
@@ -89,31 +88,31 @@
         </trans-unit>
         <trans-unit id="InvalidFontMessage" translate="yes" xml:space="preserve">
           <source>Sorry, we couldn't find any supported font data in this file.</source>
-          <target state="translated">Pedimos desculpa, não encontramos nenhum dado de fonte suportado neste ficheiro.</target>
+          <target state="translated">Pedimos desculpa, mas não conseguimos encontrar nenhum dado de tipo de letra suportado neste ficheiro.</target>
         </trans-unit>
         <trans-unit id="InvalidFontTitle" translate="yes" xml:space="preserve">
           <source>Unsupported File</source>
-          <target state="translated">Ficheiro não Suportado</target>
+          <target state="translated">Ficheiro não suportado</target>
         </trans-unit>
         <trans-unit id="OpenInNewWindow.Text" translate="yes" xml:space="preserve">
           <source>Open in New Window</source>
-          <target state="translated">Abrir numa Nova Janela</target>
+          <target state="translated">Abrir numa nova janela</target>
         </trans-unit>
         <trans-unit id="RemoveFontFlyout.Text" translate="yes" xml:space="preserve">
           <source>Delete Font</source>
-          <target state="translated">Eliminar Fonte</target>
+          <target state="translated">Eliminar tipo de letra</target>
         </trans-unit>
         <trans-unit id="RestartButton.Content" translate="yes" xml:space="preserve">
           <source>Restart app</source>
-          <target state="translated">Reiniciar aplicação</target>
+          <target state="translated">Reiniciar a aplicação</target>
         </trans-unit>
         <trans-unit id="RestartHeader.Text" translate="yes" xml:space="preserve">
           <source>Requires application restart to take effect.</source>
-          <target state="translated">Requer a reinicialização da aplicação para fazer efeito.</target>
+          <target state="translated">Verá a sua alteração quando voltar a iniciar a aplicação.</target>
         </trans-unit>
         <trans-unit id="SearchBox.PlaceholderText" translate="yes" xml:space="preserve">
-          <source>Search character name or unicode hex</source>
-          <target state="translated">Pesquise o nome do caráter ou o unicode hex</target>
+          <source>Search by name or unicode hex</source>
+          <target state="translated">Procurar por nome ou hexadecimal unicode</target>
         </trans-unit>
         <trans-unit id="Settings_About.Text" translate="yes" xml:space="preserve">
           <source>About this application</source>
@@ -121,7 +120,7 @@
         </trans-unit>
         <trans-unit id="Settings_AboutDescription.Text" translate="yes" xml:space="preserve">
           <source>This app is designed to replace the Windows Win32 Character Map. It is more DPI aware on high DPI screens.</source>
-          <target state="translated">Esta aplicação foi projetada para substituir o Mapa de carateres do Windows Win32. É mais consciente do DPI em ecrãs de DPI alto.</target>
+          <target state="translated">Esta aplicação foi projetada para substituir o Mapa de carateres (Win32) do Windows. É mais consciente do PPP em ecrãs com PPP alto.</target>
         </trans-unit>
         <trans-unit id="TxtCopiedMessage.Text" translate="yes" xml:space="preserve">
           <source>Copied</source>
@@ -129,17 +128,17 @@
         </trans-unit>
         <trans-unit id="TxtFontIcon.Header" translate="yes" xml:space="preserve">
           <source>Font Icon</source>
-          <target state="translated">Font Icon</target>
+          <target state="new">Font Icon</target>
           <note from="MultilingualBuild" annotates="source" priority="2">Xaml FontIcon. Does not need translation.</note>
         </trans-unit>
         <trans-unit id="TxtSymbolIcon.Header" translate="yes" xml:space="preserve">
           <source>Symbol Icon</source>
-          <target state="translated">Symbol Icon</target>
+          <target state="new">Symbol Icon</target>
           <note from="MultilingualBuild" annotates="source" priority="2">Xaml SymbolIcon. Does not need translation.</note>
         </trans-unit>
         <trans-unit id="TxtTitle.Text" translate="yes" xml:space="preserve">
           <source>Character Map</source>
-          <target state="translated">Mapa de Carateres</target>
+          <target state="translated">Mapa de caracteres</target>
         </trans-unit>
         <trans-unit id="TxtUnicode.Header" translate="yes" xml:space="preserve">
           <source>Unicode</source>
@@ -147,15 +146,15 @@
         </trans-unit>
         <trans-unit id="TxtXamlCode.Header" translate="yes" xml:space="preserve">
           <source>Glyph Code</source>
-          <target state="translated">Glyph Code</target>
+          <target state="translated">Código do glifo</target>
         </trans-unit>
         <trans-unit id="TypographyVariantsHeader.Text" translate="yes" xml:space="preserve">
           <source>Glyph Variants</source>
-          <target state="translated">Glyph Variants</target>
+          <target state="translated">Alternativas estilísticas</target>
         </trans-unit>
         <trans-unit id="WhiteFill.Text" translate="yes" xml:space="preserve">
           <source>White Fill</source>
-          <target state="translated">Preenchimento Branco</target>
+          <target state="translated">Preenchimento branco</target>
         </trans-unit>
         <trans-unit id="ImportNotAFile" translate="yes" xml:space="preserve">
           <source>Not a file</source>
@@ -163,7 +162,7 @@
         </trans-unit>
         <trans-unit id="ImportPendingDelete" translate="yes" xml:space="preserve">
           <source>Existing font pending delete. Please restart app.</source>
-          <target state="translated">Fonte existente pendente para eliminação. Por favor, reinicie a aplicação.</target>
+          <target state="translated">Eliminação do tipo de letra pendente. Reinicie a aplicação.</target>
         </trans-unit>
         <trans-unit id="ImportUnavailableFile" translate="yes" xml:space="preserve">
           <source>File not available</source>
@@ -171,23 +170,23 @@
         </trans-unit>
         <trans-unit id="ImportUnsupportedFileType" translate="yes" xml:space="preserve">
           <source>Unsupported File Type</source>
-          <target state="translated">Tipo de Ficheiro não Suportado</target>
+          <target state="translated">Ficheiro não suportado</target>
         </trans-unit>
         <trans-unit id="ImportUnsupportedFontType" translate="yes" xml:space="preserve">
           <source>Unsupported Font Type</source>
-          <target state="translated">Tipo de Fonte não Suportado</target>
+          <target state="translated">Tipo de letra não suportado</target>
         </trans-unit>
         <trans-unit id="FontsClearedOnNextLaunchNotice" translate="yes" xml:space="preserve">
           <source>Some fonts could not be completely removed right now. These fonts will not show in the application and will be completely removed next time the app is launched.</source>
-          <target state="translated">Algumas fontes não podem ser completamente eliminadas agora. Essas fontes não vão aparecer na aplicação e serão completamente eliminadas na próxima vez que a aplicação for iniciado.</target>
+          <target state="translated">Alguns tipos de letra não foram completamente removidos. Esses tipos de letra não vão aparecer na aplicação e serão completamente removidos na próxima vez que voltar a iniciar a aplicação.</target>
         </trans-unit>
         <trans-unit id="SaveImageError" translate="yes" xml:space="preserve">
           <source>Sorry, something went wrong whilst we were trying to save the image.</source>
-          <target state="translated">Pedimos desculpa, aconteceu algo de errado enquanto estávamos a tentar guardar a imagem.</target>
+          <target state="translated">Pedimos desculpa, ocorreu um erro ao tentar guardar a imagem.</target>
         </trans-unit>
         <trans-unit id="LoadingFontListError" translate="yes" xml:space="preserve">
           <source>Error Loading Font List</source>
-          <target state="translated">Erro ao Carregar Lista de Fontes</target>
+          <target state="translated">Erro ao carregar a lista de tipos de letra</target>
         </trans-unit>
         <trans-unit id="NoticeLabel.Text" translate="yes" xml:space="preserve">
           <source>Notice</source>
@@ -195,15 +194,15 @@
         </trans-unit>
         <trans-unit id="ImportFileCopyFail" translate="yes" xml:space="preserve">
           <source>Something went wrong. Please try again later.</source>
-          <target state="translated">Aconteceu algo de errado. Por favor, tente novamente mais tarde.</target>
+          <target state="translated">Ocorreu um problema. Tente novamente.</target>
         </trans-unit>
         <trans-unit id="ImportFontHelpBlock.Text" translate="yes" xml:space="preserve">
           <source>Drag fonts into the app to copy them to your library.</source>
-          <target state="translated">Arraste fontes para a aplicação para copiá-las na sua biblioteca.</target>
+          <target state="translated">Arraste ficheiros de tipo de letra e largue-os na aplicação para copiar tipos de letra à sua biblioteca.</target>
         </trans-unit>
         <trans-unit id="FontPropXaml.Text" translate="yes" xml:space="preserve">
           <source>XAML FontFamily Source</source>
-          <target state="translated">XAML FontFamily Source</target>
+          <target state="new">XAML FontFamily Source</target>
         </trans-unit>
         <trans-unit id="FilePickerConfirm" translate="yes" xml:space="preserve">
           <source>Import</source>
@@ -211,15 +210,19 @@
         </trans-unit>
         <trans-unit id="ImportFontsButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" translate="yes" xml:space="preserve">
           <source>Import Fonts</source>
-          <target state="translated">Importar Fontes</target>
+          <target state="translated">Importar tipos de letra</target>
         </trans-unit>
         <trans-unit id="OpenFontButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" translate="yes" xml:space="preserve">
           <source>Open Font</source>
-          <target state="translated">Abrir Fonte</target>
+          <target state="translated">Abrir tipo de letra</target>
         </trans-unit>
         <trans-unit id="OpenFontPickerConfirm" translate="yes" xml:space="preserve">
           <source>Open</source>
           <target state="translated">Abrir</target>
+        </trans-unit>
+        <trans-unit id="CreateCollectionEntryBox.Header" translate="yes" xml:space="preserve">
+          <source>Collection Name</source>
+          <target state="translated">Nome da coleção</target>
         </trans-unit>
         <trans-unit id="DigCreateCollection.PrimaryButtonText" translate="yes" xml:space="preserve">
           <source>Create</source>
@@ -227,11 +230,11 @@
         </trans-unit>
         <trans-unit id="DigCreateCollection.Title" translate="yes" xml:space="preserve">
           <source>Create Collection</source>
-          <target state="translated">Criar Coleção</target>
+          <target state="translated">Criar coleção</target>
         </trans-unit>
         <trans-unit id="DeleteCollectionButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" translate="yes" xml:space="preserve">
           <source>Delete Collection</source>
-          <target state="translated">Eliminar Coleção</target>
+          <target state="translated">Eliminar coleção</target>
         </trans-unit>
         <trans-unit id="DigCreateCollection.SecondaryButtonText" translate="yes" xml:space="preserve">
           <source>Cancel</source>
@@ -247,7 +250,7 @@
         </trans-unit>
         <trans-unit id="DigDeleteCollection.Title" translate="yes" xml:space="preserve">
           <source>Are you sure you want to delete this collection?</source>
-          <target state="translated">Tem a certeza de que quer eliminar esta coleção?</target>
+          <target state="translated">Tem a certeza de que pretende eliminar esta coleção?</target>
         </trans-unit>
         <trans-unit id="DigRenameCollection.PrimaryButtonText" translate="yes" xml:space="preserve">
           <source>Rename</source>
@@ -255,75 +258,75 @@
         </trans-unit>
         <trans-unit id="DigRenameCollection.Title" translate="yes" xml:space="preserve">
           <source>Rename Collection</source>
-          <target state="translated">Mudar o nome da Coleção</target>
+          <target state="translated">Mudar o nome da coleção</target>
         </trans-unit>
         <trans-unit id="OptionAllFonts.Text" translate="yes" xml:space="preserve">
           <source>All Fonts</source>
-          <target state="translated">Todas as Fontes</target>
+          <target state="translated">Todos os tipos de letra</target>
         </trans-unit>
         <trans-unit id="OptionImportedFonts.Text" translate="yes" xml:space="preserve">
           <source>Imported Fonts</source>
-          <target state="translated">Fontes Importadas</target>
+          <target state="translated">Tipos de letra importados</target>
         </trans-unit>
         <trans-unit id="OptionSymbolFonts.Text" translate="yes" xml:space="preserve">
           <source>Symbol Fonts</source>
-          <target state="translated">Fontes de Símbolos</target>
+          <target state="translated">Tipos de letra de símbolos</target>
         </trans-unit>
         <trans-unit id="RenameCollectionButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" translate="yes" xml:space="preserve">
           <source>Rename Collection</source>
-          <target state="translated">Mudar o nome da Coleção</target>
+          <target state="translated">Mudar o nome da coleção</target>
         </trans-unit>
         <trans-unit id="FontListDisplayHeader.Text" translate="yes" xml:space="preserve">
           <source>Fonts List Display</source>
-          <target state="translated">Visualização da Lista de Fontes</target>
+          <target state="translated">Visualizador da lista de tipos de letra</target>
         </trans-unit>
         <trans-unit id="FontPropCount.Text" translate="yes" xml:space="preserve">
           <source>Glyph Count</source>
-          <target state="translated">Glyph Count</target>
+          <target state="translated">Número de glifos</target>
         </trans-unit>
         <trans-unit id="OptionMonospacedFonts.Text" translate="yes" xml:space="preserve">
           <source>Monospaced Fonts</source>
-          <target state="translated">Fontes Monoespaçadas</target>
+          <target state="translated">Tipos de letra monoespaçada</target>
         </trans-unit>
         <trans-unit id="OptionSansSerifFonts.Text" translate="yes" xml:space="preserve">
           <source>Sans Serif Fonts</source>
-          <target state="translated">Fontes sem Serifa</target>
+          <target state="translated">Tipos de letra sem serifa</target>
         </trans-unit>
         <trans-unit id="OptionSerifFonts.Text" translate="yes" xml:space="preserve">
           <source>Serif Fonts</source>
-          <target state="translated">Fontes Serifadas</target>
+          <target state="translated">Tipos de letra serifa</target>
         </trans-unit>
         <trans-unit id="NewCollectionItem.Text" translate="yes" xml:space="preserve">
           <source>New Collection</source>
-          <target state="translated">Nova Coleção</target>
+          <target state="translated">Nova coleção</target>
         </trans-unit>
         <trans-unit id="RemoveFromCollectionItem.Text" translate="yes" xml:space="preserve">
           <source>Remove from Collection</source>
-          <target state="translated">Remover da Coleção</target>
+          <target state="translated">Remover da coleção</target>
         </trans-unit>
         <trans-unit id="AddToCollectionFlyout.Text" translate="yes" xml:space="preserve">
           <source>Add to Collection</source>
-          <target state="translated">Adicionar à Coleção</target>
+          <target state="translated">Adicionar à coleção</target>
         </trans-unit>
         <trans-unit id="InstantSearchToggle.OffContent" translate="yes" xml:space="preserve">
           <source>Instant search disabled</source>
-          <target state="translated">Pesquisa instantânea desativada</target>
+          <target state="translated">Procura instantânea desligada</target>
         </trans-unit>
         <trans-unit id="InstantSearchToggle.OnContent" translate="yes" xml:space="preserve">
           <source>Instant search enabled</source>
-          <target state="translated">Pesquisa instantânea ativada</target>
+          <target state="translated">Procura instantânea ligada</target>
         </trans-unit>
         <trans-unit id="SearchResultsSlider.Header" translate="yes" xml:space="preserve">
           <source>Maximum search results</source>
-          <target state="translated">Resultados máximos da pesquisa</target>
+          <target state="translated">Máximo de resultados da procura</target>
         </trans-unit>
         <trans-unit id="FontPropCharCount.Text" translate="yes" xml:space="preserve">
           <source>Character Count</source>
-          <target state="translated">Contagem de Carateres</target>
+          <target state="translated">Número de caracteres</target>
         </trans-unit>
         <trans-unit id="FontPropFilePath.Text" translate="yes" xml:space="preserve">
           <source>File Path</source>
-          <target state="translated">Localização do Ficheiro</target>
+          <target state="translated">Localização do ficheiro</target>
         </trans-unit>
         <trans-unit id="DWriteSourceAppxPackage" translate="yes" xml:space="preserve">
           <source>Microsoft Store</source>
@@ -331,23 +334,23 @@
         </trans-unit>
         <trans-unit id="DWriteSourcePerMachine" translate="yes" xml:space="preserve">
           <source>All Users</source>
-          <target state="translated">Todos os Utilizadores</target>
+          <target state="translated">Todos os utilizadores</target>
         </trans-unit>
         <trans-unit id="DWriteSourcePerUser" translate="yes" xml:space="preserve">
           <source>Current User only</source>
-          <target state="translated">Apenas o Utilizador Atual</target>
+          <target state="translated">Apenas o utilizador atual</target>
         </trans-unit>
         <trans-unit id="DWriteSourceRemoteFontProvider" translate="yes" xml:space="preserve">
           <source>Cloud Provider</source>
-          <target state="translated">Fornecedor de Nuvem</target>
+          <target state="translated">Fornecedor de nuvem</target>
         </trans-unit>
         <trans-unit id="DWriteSourceUnknown" translate="yes" xml:space="preserve">
           <source>Undefined</source>
-          <target state="translated">Indefinido</target>
+          <target state="translated">Indeterminada</target>
         </trans-unit>
         <trans-unit id="FontPropInstallType.Text" translate="yes" xml:space="preserve">
           <source>Install Type</source>
-          <target state="translated">Instalar Tipo</target>
+          <target state="translated">Tipo de instalação</target>
         </trans-unit>
         <trans-unit id="OptionAppxFonts.Text" translate="yes" xml:space="preserve">
           <source>From Microsoft Store</source>
@@ -355,15 +358,15 @@
         </trans-unit>
         <trans-unit id="OptionCloudFonts.Text" translate="yes" xml:space="preserve">
           <source>Cloud-based Fonts</source>
-          <target state="translated">Fontes baseadas em Nuvem</target>
+          <target state="translated">Tipos de letra da nuvem</target>
         </trans-unit>
         <trans-unit id="OptionColorFonts.Text" translate="yes" xml:space="preserve">
           <source>Color Fonts</source>
-          <target state="translated">Fontes de Cor</target>
+          <target state="translated">Tipos de letra de cor</target>
         </trans-unit>
         <trans-unit id="OptionDecorativeFonts.Text" translate="yes" xml:space="preserve">
           <source>Decorative Fonts</source>
-          <target state="translated">Fontes Decorativas</target>
+          <target state="translated">Tipos de letra decorativa</target>
         </trans-unit>
         <trans-unit id="OptionMoreFilters.Text" translate="yes" xml:space="preserve">
           <source>More</source>
@@ -371,67 +374,67 @@
         </trans-unit>
         <trans-unit id="OptionScriptFonts.Text" translate="yes" xml:space="preserve">
           <source>Script Fonts</source>
-          <target state="translated">Fontes de Script</target>
+          <target state="translated">Tipos de letra manuscrita</target>
         </trans-unit>
         <trans-unit id="StatusBarFontCount" translate="yes" xml:space="preserve">
           <source>{0} Font Families</source>
-          <target state="translated">{0} Famílias de Fontes</target>
+          <target state="translated">{0} família(s) tipográfica(s)</target>
         </trans-unit>
         <trans-unit id="FontPropFileSize.Text" translate="yes" xml:space="preserve">
           <source>File Size</source>
-          <target state="translated">Tamanho do Ficheiro</target>
+          <target state="translated">Tamanho do ficheiro</target>
         </trans-unit>
         <trans-unit id="InstallTypeImported" translate="yes" xml:space="preserve">
           <source>Not Installed (Imported)</source>
-          <target state="translated">Não Instalado (Importado)</target>
+          <target state="translated">Não instalada (importada)</target>
         </trans-unit>
         <trans-unit id="StatusBarCharacterCount" translate="yes" xml:space="preserve">
           <source>{0} Characters</source>
-          <target state="translated">{0} Carater(es)</target>
+          <target state="translated">{0} caracteres</target>
         </trans-unit>
         <trans-unit id="SearchDelaySelector.Header" translate="yes" xml:space="preserve">
           <source>Delay before search (ms)</source>
-          <target state="translated">Atraso antes da pesquisa (ms)</target>
+          <target state="translated">Atraso antes da procura (ms)</target>
         </trans-unit>
         <trans-unit id="InstantSearchToggleHeader.Text" translate="yes" xml:space="preserve">
           <source>Instant Search</source>
-          <target state="translated">Pesquisa Instantânea</target>
+          <target state="translated">Procura instantânea</target>
         </trans-unit>
         <trans-unit id="CharacterSavedMessage.Text" translate="yes" xml:space="preserve">
           <source>Saved to</source>
-          <target state="translated">Guardado para</target>
+          <target state="translated">Guardado em</target>
         </trans-unit>
         <trans-unit id="NotificationAddedToCollection" translate="yes" xml:space="preserve">
           <source>{0} was added to "{1}" collection</source>
-          <target state="translated">{0} foi adicionado para a coleção "{1}"</target>
+          <target state="translated">{0} foi adicionada à coleção "{1}"</target>
         </trans-unit>
         <trans-unit id="BtnOpenFile.Content" translate="yes" xml:space="preserve">
           <source>Open File</source>
-          <target state="translated">Abrir Ficheiro</target>
+          <target state="translated">Abrir ficheiro</target>
         </trans-unit>
         <trans-unit id="BtnOpenFolder.Content" translate="yes" xml:space="preserve">
           <source>Show in Folder</source>
-          <target state="translated">Mostrar numa Pasta</target>
+          <target state="translated">Mostrar numa pasta</target>
         </trans-unit>
         <trans-unit id="BtnHidePane.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" translate="yes" xml:space="preserve">
           <source>Hide font pane (Ctrl+L)</source>
-          <target state="translated">Ocultar painel de fontes (Ctrl+L)</target>
+          <target state="translated">Ocultar painel de tipos de letra (Ctrl+L)</target>
         </trans-unit>
         <trans-unit id="NotificationImportFailed" translate="yes" xml:space="preserve">
           <source>Import Failed</source>
-          <target state="translated">Importação Falhada</target>
+          <target state="translated">A importação falhou</target>
         </trans-unit>
         <trans-unit id="NotificationMultipleFontsAdded" translate="yes" xml:space="preserve">
           <source>{0} files were added to your collection</source>
-          <target state="translated">{0} ficheiros foram adicionados para a sua coleção</target>
+          <target state="translated">{0} ficheiros foram adicionados à tua coleção</target>
         </trans-unit>
         <trans-unit id="NotificationSingleFontAdded" translate="yes" xml:space="preserve">
           <source>{0} was added to your collection</source>
-          <target state="translated">{0} foi adicionado para a sua coleção</target>
+          <target state="translated">{0} foi adicionado à tua coleção</target>
         </trans-unit>
         <trans-unit id="BtnShowPane.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" translate="yes" xml:space="preserve">
           <source>Show font pane (Ctrl+L)</source>
-          <target state="translated">Mostrar painel de fontes (Ctrl+L)</target>
+          <target state="translated">Mostrar painel de tipos de letra (Ctrl+L)</target>
         </trans-unit>
         <trans-unit id="BtnMoreIcon.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" translate="yes" xml:space="preserve">
           <source>More</source>
@@ -439,19 +442,19 @@
         </trans-unit>
         <trans-unit id="FontListFilter.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" translate="yes" xml:space="preserve">
           <source>Filter fonts</source>
-          <target state="translated">Filtrar fontes</target>
+          <target state="translated">Filtrar tipos de letra</target>
         </trans-unit>
         <trans-unit id="ToggleFullScreenModeButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" translate="yes" xml:space="preserve">
           <source>Toggle Fullscreen</source>
-          <target state="translated">Trocar para Ecrã Inteiro</target>
+          <target state="translated">Alternar ecrã inteiro</target>
         </trans-unit>
         <trans-unit id="DlgDeleteFont.Title" translate="yes" xml:space="preserve">
           <source>Are you sure you want to delete this font from your library?</source>
-          <target state="translated">Tem a certeza de que quer apagar esta fonte da sua biblioteca?</target>
+          <target state="translated">Tem a certeza de que pretende eliminar este tipo de letra da biblioteca?</target>
         </trans-unit>
         <trans-unit id="NotificationCollectionDeleted" translate="yes" xml:space="preserve">
           <source>"{0}" collection deleted</source>
-          <target state="translated">Coleção "{0}" eliminada</target>
+          <target state="translated">"{0}" coleção eliminada</target>
         </trans-unit>
         <trans-unit id="DlgException.PrimaryButtonText" translate="yes" xml:space="preserve">
           <source>OK</source>
@@ -463,15 +466,15 @@
         </trans-unit>
         <trans-unit id="DlgExceptionCopyMessage.Text" translate="yes" xml:space="preserve">
           <source>Copy error to Clipboard and open GitHub</source>
-          <target state="translated">Copiar erro para a Área de Transferências e abrir GitHub</target>
+          <target state="translated">Copiar erro para a Área de Transferência e abrir o GitHub</target>
         </trans-unit>
         <trans-unit id="DlgExceptionExpander.Header" translate="yes" xml:space="preserve">
           <source>View Full Exception details</source>
-          <target state="translated">Ver Detalhes Completos da Exceção</target>
+          <target state="translated">Ver detalhes completos da excepção</target>
         </trans-unit>
         <trans-unit id="DlgExceptionMessage.Text" translate="yes" xml:space="preserve">
           <source>To help us debug and fix this for you, please consider opening an issue on our GitHub page and posting the details. We'll try and fix it right away!</source>
-          <target state="translated">Para nos ajudar a depurar e corrigir isto para si, por favor, considere abrir um problema na nossa página GitHub e afixar os detalhes. Tentaremos corrigi-lo de imediato!</target>
+          <target state="translated">Para nos ajudar a depurar e a resolvê-lo, considere criar uma relatório de erro que nos pode enviar os detalhes na nossa página no GitHub. Tentaremos corrigir imediatamente!</target>
         </trans-unit>
         <trans-unit id="BtnClose.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" translate="yes" xml:space="preserve">
           <source>Close</source>
@@ -483,11 +486,11 @@
         </trans-unit>
         <trans-unit id="BtnRateAndReview.Content" translate="yes" xml:space="preserve">
           <source>Rate &amp; Review</source>
-          <target state="translated">Classifique &amp; Avalie</target>
+          <target state="translated">Classifique &amp; critique</target>
         </trans-unit>
         <trans-unit id="BtnXAMLGeometry.Content" translate="yes" xml:space="preserve">
           <source>Click to view</source>
-          <target state="translated">Clique para ver</target>
+          <target state="translated">Premir para ver</target>
         </trans-unit>
         <trans-unit id="RbThemeDark.Content" translate="yes" xml:space="preserve">
           <source>Dark</source>
@@ -499,65 +502,65 @@
         </trans-unit>
         <trans-unit id="RbThemeSystem.Content" translate="yes" xml:space="preserve">
           <source>Windows default</source>
-          <target state="translated">Predefinição do Windows</target>
+          <target state="translated">Utilizar definição do sistema</target>
         </trans-unit>
         <trans-unit id="RbUseActualFont.Content" translate="yes" xml:space="preserve">
           <source>Use actual font</source>
-          <target state="translated">Utilizar fonte atual</target>
+          <target state="translated">Utilizar tipo de letra atual</target>
         </trans-unit>
         <trans-unit id="RbUseSystemFont.Content" translate="yes" xml:space="preserve">
           <source>Use system font</source>
-          <target state="translated">Utilizar fonte do sistema</target>
+          <target state="translated">Utilizar tipo de letra do sistema</target>
         </trans-unit>
         <trans-unit id="SettingsCharacterSearchDescription.Text" translate="yes" xml:space="preserve">
           <source>Toggle instant search. If disabled, you can start a search by using the enter key or pressing the search icon.</source>
-          <target state="translated">Trocar para a pesquisa instantânea. Se desativado, você pode iniciar uma pesquisa utilizando a tecla Enter ou pressionando o ícone de pesquisar.</target>
+          <target state="translated">Mudar procura instantânea. Ao desligar, a procura inicia ao premir a tecla Enter ou o ícone de procura.</target>
         </trans-unit>
         <trans-unit id="SettingsCharacterSearchHeader.Text" translate="yes" xml:space="preserve">
           <source>Character Search</source>
-          <target state="translated">Pesquisa de Carateres</target>
+          <target state="translated">Procura de caracteres</target>
         </trans-unit>
         <trans-unit id="SettingsCharGridDescription.Text" translate="yes" xml:space="preserve">
           <source>The size of individual characters inside the character grid. Smaller sizes may affect performance.</source>
-          <target state="translated">O tamanho dos carateres individuais dentro da grelha de carateres. Tamanhos menores podem afetar o desempenho.</target>
+          <target state="translated">O tamanho dos caracteres individuais dentro da grelha de caracteres. Tamanhos menores podem afetar o desempenho.</target>
         </trans-unit>
         <trans-unit id="SettingsCharGridHeader.Text" translate="yes" xml:space="preserve">
           <source>Character Grid Size</source>
-          <target state="translated">Tamanho da Grelha de Carateres</target>
+          <target state="translated">Tamanho da grelha de caracteres</target>
         </trans-unit>
         <trans-unit id="SettingsCharPreviewHint.Text" translate="yes" xml:space="preserve">
           <source>Character grid preview</source>
-          <target state="translated">Pré-visualização da grelha de carateres</target>
+          <target state="translated">Pré-visualização da grelha de caracteres</target>
         </trans-unit>
         <trans-unit id="SettingsDevToolsDescription.Text" translate="yes" xml:space="preserve">
           <source>Show the tools for XAML developers, like Symbol Icon and Font Icon.</source>
-          <target state="translated">Mostrar ferramentas para desenvolvedores XAML, como Ícone de Símbolo e Ícone de Fonte.</target>
+          <target state="translated">Mostrar as ferramentas para programdores XAML, como Symbol Icon e Font Icon.</target>
         </trans-unit>
         <trans-unit id="SettingsDevToolsGroupHeader.Text" translate="yes" xml:space="preserve">
           <source>Developer Features</source>
-          <target state="translated">Funcionalidades de Desenvolvedor</target>
+          <target state="translated">Funcionalidades de programador</target>
         </trans-unit>
         <trans-unit id="SettingsDevToolsHeader.Text" translate="yes" xml:space="preserve">
           <source>Show developers features</source>
-          <target state="translated">Mostrar funcionalidades de desenvolvedor</target>
+          <target state="translated">Mostrar funcionalidades de programador</target>
         </trans-unit>
         <trans-unit id="SettingsDevToolsLangDescription.Text" translate="yes" xml:space="preserve">
           <source>Choose the dev language for developer features content.</source>
-          <target state="translated">Escolha a linguagem de desenvolvimento para o conteúdo das funcionalidades do desenvolvedor.</target>
+          <target state="translated">Escolha a linguagem de programação para o conteúdo das funcionalidades de programador.</target>
         </trans-unit>
         <trans-unit id="SettingsDevToolsLangHeader.Text" translate="yes" xml:space="preserve">
           <source>Language</source>
-          <target state="translated">Linguagem</target>
+          <target state="translated">Idioma</target>
         </trans-unit>
         <trans-unit id="SettingsExpensiveAnimationDescription.Text" translate="yes" xml:space="preserve">
           <source>Animates the character grid when resizing the window.
 Turning this on can incur a large performance penalty when resizing the window.</source>
-          <target state="translated">Anima a grelha de carateres ao redimensionar a janela.
-Ao ativar isto pode incorrer uma grande penalização de desempenho ao redimensionar a janela.</target>
+          <target state="translated">Anima a grelha de caracteres ao redimensionar a janela.
+Ativar esta definição pode incorrer uma grande penalização de desempenho ao redimensionar a janela.</target>
         </trans-unit>
         <trans-unit id="SettingsExpensiveAnimationHeader.Text" translate="yes" xml:space="preserve">
           <source>Enable window resize animations</source>
-          <target state="translated">Ativar animações de redimensionamento de janelas</target>
+          <target state="translated">Animações de redimensionamento da janela</target>
         </trans-unit>
         <trans-unit id="SettingsExportHeader.Text" translate="yes" xml:space="preserve">
           <source>Export</source>
@@ -565,11 +568,11 @@ Ao ativar isto pode incorrer uma grande penalização de desempenho ao redimensi
         </trans-unit>
         <trans-unit id="SettingsFontListDescription.Text" translate="yes" xml:space="preserve">
           <source>Choose the font used to display the names of fonts in the font list.</source>
-          <target state="translated">Escolha a fonte utilizada para exibir os nomes das fontes na lista de fontes.</target>
+          <target state="translated">Escolhe o tipo de letra utilizado para exibir os nomes dos tipos de letra na lista de tipos de letra.</target>
         </trans-unit>
         <trans-unit id="SettingsFontListPreviewHint.Text" translate="yes" xml:space="preserve">
           <source>Font list preview</source>
-          <target state="translated">Pré-visualização da lista de fontes</target>
+          <target state="translated">Pré-visualização da lista de tipos de letra</target>
         </trans-unit>
         <trans-unit id="SettingsHeader.Text" translate="yes" xml:space="preserve">
           <source>Settings</source>
@@ -579,7 +582,7 @@ Ao ativar isto pode incorrer uma grande penalização de desempenho ao redimensi
           <source>Override the in-app language.
 Requires a restart to take effect.</source>
           <target state="translated">Substituir o idioma na aplicação.
-Requer a reinicialização para ter efeito.</target>
+Verá a sua alteração quando voltar a iniciar a aplicação.</target>
         </trans-unit>
         <trans-unit id="SettingsLanguageHeader.Text" translate="yes" xml:space="preserve">
           <source>Language override</source>
@@ -587,54 +590,54 @@ Requer a reinicialização para ter efeito.</target>
         </trans-unit>
         <trans-unit id="SettingsPNGExportDescription.Text" translate="yes" xml:space="preserve">
           <source>The size in pixels of exported PNG images.</source>
-          <target state="translated">O tamanho em pixels das imagens PNG exportadas.</target>
+          <target state="translated">O tamanho, em píxeis, das imagens PNG exportadas.</target>
         </trans-unit>
         <trans-unit id="SettingsPNGExportHeader.Text" translate="yes" xml:space="preserve">
           <source>PNG Export Size</source>
-          <target state="translated">Tamanho da Exportação PNG</target>
+          <target state="translated">Tamanho da exportação PNG</target>
         </trans-unit>
         <trans-unit id="SettingsShadowsDescription.Text" translate="yes" xml:space="preserve">
           <source>Enables subtle depth shadows on the UI. Only noticeable when using the Light theme.
 Turning this on may have a small performance impact on weaker devices.
 Requires a restart to take effect.</source>
-          <target state="translated">Permite sombras subtis de profundidade na IU. Apenas perceptível quando se utiliza o tema Claro.
-Ativar isto pode ter um pequeno impacto no desempenho de dispositivos mais fracos.
-Requer a reinicialização para ter efeito.</target>
+          <target state="translated">Ativa sombras de profundidade subtis na IU. Apenas percetível ao utilizar o tema claro.
+Ativar esta opção pode ter um pequeno impacto no desempenho em dispositivos mais fracos.
+Verá a sua alteração quando voltar a iniciar a aplicação.</target>
         </trans-unit>
         <trans-unit id="SettingsShadowsHeader.Text" translate="yes" xml:space="preserve">
           <source>Enable shadows</source>
-          <target state="translated">Ativar sombras</target>
+          <target state="translated">Sombras</target>
         </trans-unit>
         <trans-unit id="SettingsSimpleAnimationDescription.Text" translate="yes" xml:space="preserve">
-          <source>Controls the animation for loading the font list, switching fonts and changing characters.
+          <source>Controls most animations inside the application. Turning this off will disable most animations.
 Turning this on has negligible performance impact.</source>
-          <target state="translated">Controla a animação para carregar a lista de fontes, mudar as fontes e mudar os carateres.
-Ativar isto tem um impacto de desempenho negligenciável.</target>
+          <target state="translated">Controla a maioria das animações dentro da aplicação. Desligar esta opção desativa a maioria das animações.
+Ativar esta opção tem um impacto insignificante no desempenho.</target>
         </trans-unit>
         <trans-unit id="SettingsSimpleAnimationHeader.Text" translate="yes" xml:space="preserve">
-          <source>Enable simple animations</source>
-          <target state="translated">Ativar animações simples</target>
+          <source>Enable animations</source>
+          <target state="translated">Animações</target>
         </trans-unit>
         <trans-unit id="SettingsThemeHeader.Text" translate="yes" xml:space="preserve">
           <source>Theme</source>
           <target state="translated">Tema</target>
         </trans-unit>
         <trans-unit id="SettingsUIHeader.Text" translate="yes" xml:space="preserve">
-          <source>User Interface</source>
-          <target state="translated">Interface de Utilizador</target>
+          <source>Layout</source>
+          <target state="translated">Esquema</target>
         </trans-unit>
         <trans-unit id="TxtPathGeometry.Text" translate="yes" xml:space="preserve">
           <source>Path Geometry</source>
-          <target state="translated">Path Geometry</target>
+          <target state="new">Path Geometry</target>
           <note from="MultilingualBuild" annotates="source" priority="2">Xaml PathGeometry. Does not need translation.</note>
         </trans-unit>
         <trans-unit id="UseSystemLanguage" translate="yes" xml:space="preserve">
           <source>Use system language setting</source>
-          <target state="translated">Utilizar definição de idioma do sistema</target>
+          <target state="translated">Utilizar o idioma de apresentação do sistema</target>
         </trans-unit>
         <trans-unit id="SettingsNeedRestart.Text" translate="yes" xml:space="preserve">
           <source>Change will apply after restart</source>
-          <target state="translated">A alteração será aplicada após reinício</target>
+          <target state="translated">Verá a sua alteração quando voltar a iniciar a aplicação</target>
         </trans-unit>
         <trans-unit id="BtnContributors.Content" translate="yes" xml:space="preserve">
           <source>Contributors</source>
@@ -642,7 +645,7 @@ Ativar isto tem um impacto de desempenho negligenciável.</target>
         </trans-unit>
         <trans-unit id="TxtLoadingFonts.Text" translate="yes" xml:space="preserve">
           <source>Loading Fonts</source>
-          <target state="translated">A Carregar Fontes</target>
+          <target state="translated">A carregar tipos de letra</target>
         </trans-unit>
         <trans-unit id="AppBtnClear.Label" translate="yes" xml:space="preserve">
           <source>Clear</source>
@@ -654,7 +657,7 @@ Ativar isto tem um impacto de desempenho negligenciável.</target>
         </trans-unit>
         <trans-unit id="AppBtnSelectAll.Label" translate="yes" xml:space="preserve">
           <source>Select All</source>
-          <target state="translated">Selecionar Tudo</target>
+          <target state="translated">Selecionar tudo</target>
         </trans-unit>
         <trans-unit id="BtnApply.Content" translate="yes" xml:space="preserve">
           <source>Apply</source>
@@ -668,21 +671,25 @@ Ativar isto tem um impacto de desempenho negligenciável.</target>
           <source>Continue</source>
           <target state="translated">Continuar</target>
         </trans-unit>
+        <trans-unit id="BtnPrint.Content" translate="yes" xml:space="preserve">
+          <source>Print</source>
+          <target state="translated">Imprimir</target>
+        </trans-unit>
         <trans-unit id="CbCharacterLabel.Header" translate="yes" xml:space="preserve">
           <source>Character Label</source>
-          <target state="translated">Etiqueta do Carater</target>
+          <target state="translated">Etiqueta do carácter</target>
         </trans-unit>
         <trans-unit id="CbiPageOrientationLandscape.Content" translate="yes" xml:space="preserve">
           <source>Landscape</source>
-          <target state="translated">Paisagem</target>
+          <target state="translated">Vertical</target>
         </trans-unit>
         <trans-unit id="CbiPageOrientationPortrait.Content" translate="yes" xml:space="preserve">
           <source>Portrait</source>
-          <target state="translated">Retrato</target>
+          <target state="translated">Horizontal</target>
         </trans-unit>
         <trans-unit id="CbListStyle.Header" translate="yes" xml:space="preserve">
           <source>List Style</source>
-          <target state="translated">Estilo da Lista</target>
+          <target state="translated">Estilo da lista</target>
         </trans-unit>
         <trans-unit id="CbShowMargins.Content" translate="yes" xml:space="preserve">
           <source>Show margins</source>
@@ -690,31 +697,43 @@ Ativar isto tem um impacto de desempenho negligenciável.</target>
         </trans-unit>
         <trans-unit id="ChkBxHideWhitespace.Content" translate="yes" xml:space="preserve">
           <source>Hide whitespace and control characters</source>
-          <target state="translated">Ocultar espaços em branco e controlar carateres</target>
+          <target state="translated">Ocultar espaços em branco e caracteres de controlo</target>
+        </trans-unit>
+        <trans-unit id="ChkBxShowBorders.Content" translate="yes" xml:space="preserve">
+          <source>Show borders</source>
+          <target state="translated">Mostrar bordas</target>
         </trans-unit>
         <trans-unit id="GlyphAnnotation_None" translate="yes" xml:space="preserve">
           <source>None</source>
-          <target state="translated">Nenhum</target>
+          <target state="translated">Nenhuma</target>
+        </trans-unit>
+        <trans-unit id="GlyphAnnotation_UnicodeHex" translate="yes" xml:space="preserve">
+          <source>Unicode Hex</source>
+          <target state="translated">Hexademical Unicode</target>
+        </trans-unit>
+        <trans-unit id="GlyphAnnotation_UnicodeIndex" translate="yes" xml:space="preserve">
+          <source>Unicode Index</source>
+          <target state="translated">Índice Unicode</target>
         </trans-unit>
         <trans-unit id="PrintCharacterFilterContent.Text" translate="yes" xml:space="preserve">
           <source>Choose character groups to display</source>
-          <target state="translated">Escolha os grupos de carateres a exibir</target>
+          <target state="translated">Escolhe o grupo de caracteres a apresentar</target>
         </trans-unit>
         <trans-unit id="PrintDataHeader.Text" translate="yes" xml:space="preserve">
           <source>Data</source>
-          <target state="translated">Dado</target>
+          <target state="translated">Dados</target>
         </trans-unit>
         <trans-unit id="PrintViewCharSize.Text" translate="yes" xml:space="preserve">
           <source>Character Size</source>
-          <target state="translated">Tamanho do Carater</target>
+          <target state="translated">Tamanho do carácter</target>
         </trans-unit>
         <trans-unit id="PrintViewHorizontalMarginHeader.Text" translate="yes" xml:space="preserve">
           <source>Horizontal Margin</source>
-          <target state="translated">Margem Horizontal</target>
+          <target state="translated">Margem horizontal</target>
         </trans-unit>
         <trans-unit id="PrintViewLayoutHeader.Text" translate="yes" xml:space="preserve">
           <source>Layout</source>
-          <target state="translated">Layout</target>
+          <target state="translated">Esquema</target>
         </trans-unit>
         <trans-unit id="PrintViewOfLabel.Text" translate="yes" xml:space="preserve">
           <source>of</source>
@@ -722,15 +741,15 @@ Ativar isto tem um impacto de desempenho negligenciável.</target>
         </trans-unit>
         <trans-unit id="PrintViewPageOrientation.Header" translate="yes" xml:space="preserve">
           <source>Page Orientation</source>
-          <target state="translated">Orientação da Página</target>
+          <target state="translated">Orientação da página</target>
         </trans-unit>
         <trans-unit id="PrintViewPageRange.Text" translate="yes" xml:space="preserve">
           <source>Page Range</source>
-          <target state="translated">Intervalo de Página</target>
+          <target state="translated">Intervalo de páginas</target>
         </trans-unit>
         <trans-unit id="PrintViewPageRangeDesc.Text" translate="yes" xml:space="preserve">
           <source>Up to 50 pages can be printed at a time. Select the range of pages to print here.</source>
-          <target state="translated">Podem ser imprimido até 50 páginas de cada vez. Selecione aqui o intervalo de páginas a imprimir.</target>
+          <target state="translated">Podem ser impressas até 50 páginas de uma vez. Selecione aqui o intervalo de páginas a imprimir.</target>
         </trans-unit>
         <trans-unit id="PrintViewPageRangeSelector.Header" translate="yes" xml:space="preserve">
           <source>Pages to print:</source>
@@ -738,73 +757,57 @@ Ativar isto tem um impacto de desempenho negligenciável.</target>
         </trans-unit>
         <trans-unit id="PrintViewPageSelector.Header" translate="yes" xml:space="preserve">
           <source>Start from page:</source>
-          <target state="translated">Iniciar da página:</target>
+          <target state="translated">Iniciar na página:</target>
         </trans-unit>
         <trans-unit id="PrintViewPageSetupHeader.Text" translate="yes" xml:space="preserve">
           <source>Page Setup</source>
-          <target state="translated">Definição da Página</target>
+          <target state="translated">Configuração da página</target>
         </trans-unit>
         <trans-unit id="PrintViewPreviewingLabel.Text" translate="yes" xml:space="preserve">
           <source>Previewing page</source>
-          <target state="translated">Pré-visualizando a página</target>
+          <target state="translated">Pré-visualização da página</target>
         </trans-unit>
         <trans-unit id="PrintViewPreviewOutOfBoundsLabel.Text" translate="yes" xml:space="preserve">
           <source>This page is outside the current page range and will not be printed.
 You can change the page range in the Page Setup section.</source>
-          <target state="translated">Esta página está fora do intervalo de páginas atual e não será imprimido.
-Pode alterar o intervalo de páginas na secção Definição da Página.</target>
+          <target state="translated">Esta página está fora do intervalo de páginas atual e não será impressa.
+Pode alterar o intervalo de páginas na secção Configuração da página.</target>
         </trans-unit>
         <trans-unit id="PrintViewPrintingLabel" translate="yes" xml:space="preserve">
           <source>Printing pages {0} - {1}</source>
-          <target state="translated">Imprimindo páginas {0} - {1}</target>
+          <target state="translated">A imprimir página {0} - {1}</target>
         </trans-unit>
         <trans-unit id="PrintViewTitle.Text" translate="yes" xml:space="preserve">
           <source>Print Configuration</source>
-          <target state="translated">Definição de Impressão</target>
+          <target state="translated">Configuração de impressão</target>
         </trans-unit>
         <trans-unit id="PrintViewVerticalMarginHeader.Text" translate="yes" xml:space="preserve">
           <source>Vertical Margin</source>
-          <target state="translated">Margem Vertical</target>
+          <target state="translated">Margem vertical</target>
         </trans-unit>
-        <trans-unit id="UnicodeFiltersTitle.Text" translate="yes" xml:space="preserve">
-          <source>UNICODE CATEGORY FILTERS</source>
-          <target state="translated">FILTROS DA CATEGORIA UNICODE</target>
+        <trans-unit id="SettingsCharLabel.Text" translate="yes" xml:space="preserve">
+          <source>Character Label</source>
+          <target state="translated">Etiqueta do carácter</target>
         </trans-unit>
-        <trans-unit id="GlyphAnnotation_UnicodeHex" translate="yes" xml:space="preserve">
-          <source>Unicode Hex</source>
-          <target state="translated">Unicode Hex</target>
-        </trans-unit>
-        <trans-unit id="GlyphAnnotation_UnicodeIndex" translate="yes" xml:space="preserve">
-          <source>Unicode Index</source>
-          <target state="translated">Unicode Index</target>
+        <trans-unit id="SettingsCharLabelDesc.Text" translate="yes" xml:space="preserve">
+          <source>Choose the label to show under each character. May have a minor effect on scrolling performance.</source>
+          <target state="translated">Escolhe a etiqueta a mostrar debaixo de cada carácter. Pode ter um efeito menor no desempenho do deslocamento.</target>
         </trans-unit>
         <trans-unit id="SettingsManageSystemFonts.Content" translate="yes" xml:space="preserve">
           <source>Manage installed fonts</source>
-          <target state="translated">Gerir fontes instaladas</target>
+          <target state="translated">Gerir tipos de letra instalados</target>
         </trans-unit>
         <trans-unit id="SettingsSystemFontHeader.Text" translate="yes" xml:space="preserve">
           <source>Installed Fonts</source>
-          <target state="translated">Fontes Instaladas</target>
+          <target state="translated">Tipos de letra instalados</target>
         </trans-unit>
         <trans-unit id="SettingsWindowsThemeSettings.Content" translate="yes" xml:space="preserve">
           <source>Windows theme settings</source>
           <target state="translated">Definições do tema do Windows</target>
         </trans-unit>
-        <trans-unit id="SettingsCharLabel.Text" translate="yes" xml:space="preserve">
-          <source>Character Label</source>
-          <target state="translated">Etiqueta do Carater</target>
-        </trans-unit>
-        <trans-unit id="SettingsCharLabelDesc.Text" translate="yes" xml:space="preserve">
-          <source>Choose the label to show under each character. May have a minor effect on scrolling performance.</source>
-          <target state="translated">Escolha a etiqueta a mostrar sob cada carater. Pode ter um efeito menor no desempenho de deslocamento.</target>
-        </trans-unit>
-        <trans-unit id="BtnPrint.Content" translate="yes" xml:space="preserve">
-          <source>Print</source>
-          <target state="translated">Imprimir</target>
-        </trans-unit>
-        <trans-unit id="ChkBxShowBorders.Content" translate="yes" xml:space="preserve">
-          <source>Show borders</source>
-          <target state="translated">Mostrar bordas</target>
+        <trans-unit id="UnicodeFiltersTitle.Text" translate="yes" xml:space="preserve">
+          <source>UNICODE CATEGORY FILTERS</source>
+          <target state="translated">FILTROS DE CATEGORIA UNICODE</target>
         </trans-unit>
         <trans-unit id="PrintLayout_Grid" translate="yes" xml:space="preserve">
           <source>Grid</source>
@@ -816,35 +819,35 @@ Pode alterar o intervalo de páginas na secção Definição da Página.</target
         </trans-unit>
         <trans-unit id="PrintLayout_TwoColumn" translate="yes" xml:space="preserve">
           <source>Two Columns</source>
-          <target state="translated">Duas Colunas</target>
+          <target state="translated">Duas colunas</target>
         </trans-unit>
         <trans-unit id="SettingsTransparencyDescription.Text" translate="yes" xml:space="preserve">
           <source>Enables transparency effects in the UI. If transparency is disabled in Windows settings, this will have no effect.
 May have a minor effect on performance on older or weaker devices.</source>
-          <target state="translated">Ativa os efeitos de transparência na IU. Se a transparência for desativada nas definições do Windows, isto não terá qualquer efeito.
-Pode ter um efeito menor no desempenho em dispositivos mais antigos ou mais fracos.</target>
+          <target state="translated">Ativa efeitos de transparência na IU. Se os efeitos de transparência estiverem desligados nas definições do Windows, esta opção não terá qualquer efeito.
+Pode ter um pequeno efeito no desempenho em dispositivos mais antigos ou fracos.</target>
         </trans-unit>
         <trans-unit id="SettingsTransparencyHeader.Text" translate="yes" xml:space="preserve">
           <source>Enable transparency</source>
-          <target state="translated">Ativar transparência</target>
+          <target state="translated">Transparência</target>
         </trans-unit>
         <trans-unit id="StartupFailedButton.Content" translate="yes" xml:space="preserve">
           <source>Show Details</source>
-          <target state="translated">Mostrar Detalhes</target>
+          <target state="translated">Mostrar detalhes</target>
         </trans-unit>
         <trans-unit id="StartupFailedHeader.Text" translate="yes" xml:space="preserve">
           <source>Uh Oh</source>
-          <target state="translated">Uh Oh</target>
+          <target state="translated">Ups</target>
         </trans-unit>
         <trans-unit id="StartupFailedMessage.Text" translate="yes" xml:space="preserve">
           <source>Something went wrong and we couldn't start the app right now.
 Please consider posting details about this error to GitHub so we can help you fix it.</source>
-          <target state="translated">Ocorreu algo de errado e não pudemos iniciar a aplicação neste momento.
-Por favor, considere a possibilidade de colocar detalhes sobre este erro no GitHub para que o possamos ajudar a corrigi-lo.</target>
+          <target state="translated">Ocorreu um erro e não foi possível iniciar a aplicação neste momento.
+Considere colocar detalhes sobre este erro no GitHub para lhe podermos ajudar a corrigi-lo.</target>
         </trans-unit>
         <trans-unit id="CharacterKeystrokeLabel" translate="yes" xml:space="preserve">
           <source>Keystroke: Alt + {0:0000}</source>
-          <target state="translated">Pressionamento de teclas: Alt + {0: 0000}</target>
+          <target state="translated">Combinação de tecla: Alt + {0:0000}</target>
         </trans-unit>
         <trans-unit id="ExportSVGLabel.Text" translate="yes" xml:space="preserve">
           <source>Save as SVG Image</source>
@@ -856,7 +859,7 @@ Por favor, considere a possibilidade de colocar detalhes sobre este erro no GitH
         </trans-unit>
         <trans-unit id="ExportSVGGlyphLabel.Text" translate="yes" xml:space="preserve">
           <source>SVG Glyph</source>
-          <target state="translated">Glyph SVG</target>
+          <target state="translated">Glifo SVG</target>
         </trans-unit>
         <trans-unit id="BtnCopyGlyph.Label" translate="yes" xml:space="preserve">
           <source>Copy</source>
@@ -864,7 +867,7 @@ Por favor, considere a possibilidade de colocar detalhes sobre este erro no GitH
         </trans-unit>
         <trans-unit id="BtnCopyGlyph.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" translate="yes" xml:space="preserve">
           <source>Copy to clipboard</source>
-          <target state="translated">Copiar para a Área de Transferências</target>
+          <target state="translated">Copiar para a área de transferência</target>
         </trans-unit>
         <trans-unit id="BtnSaveGlyph.Label" translate="yes" xml:space="preserve">
           <source>Save As</source>
@@ -876,7 +879,7 @@ Por favor, considere a possibilidade de colocar detalhes sobre este erro no GitH
         </trans-unit>
         <trans-unit id="BtnFit.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" translate="yes" xml:space="preserve">
           <source>Fit Character</source>
-          <target state="translated">Adaptar Carater</target>
+          <target state="translated">Ajustar carácter</target>
         </trans-unit>
         <trans-unit id="NotificationFontRemovedBody.Text" translate="yes" xml:space="preserve">
           <source>was removed from</source>
@@ -884,19 +887,15 @@ Por favor, considere a possibilidade de colocar detalhes sobre este erro no GitH
         </trans-unit>
         <trans-unit id="NotificationFontAddedBody.Text" translate="yes" xml:space="preserve">
           <source>was added to</source>
-          <target state="translated">foi adicionado para</target>
-        </trans-unit>
-        <trans-unit id="CreateCollectionEntryBox.Header" translate="yes" xml:space="preserve">
-          <source>Collection Name</source>
-          <target state="translated">Nome da Coleção</target>
+          <target state="translated">foi adicionado a</target>
         </trans-unit>
         <trans-unit id="ExportFontFile.Text" translate="yes" xml:space="preserve">
           <source>Font File</source>
-          <target state="translated">Ficheiro da Fonte</target>
+          <target state="translated">Ficheiro de tipo de letra</target>
         </trans-unit>
         <trans-unit id="ExportFontFileLabel.Text" translate="yes" xml:space="preserve">
           <source>Save Font File As</source>
-          <target state="translated">Guardar Ficheiro da Fonte como</target>
+          <target state="translated">Guardar tipo de letra como</target>
         </trans-unit>
         <trans-unit id="FontExportedMessage" translate="yes" xml:space="preserve">
           <source>{0} exported</source>
@@ -904,40 +903,40 @@ Por favor, considere a possibilidade de colocar detalhes sobre este erro no GitH
         </trans-unit>
         <trans-unit id="CollectionExportButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" translate="yes" xml:space="preserve">
           <source>Export Fonts</source>
-          <target state="translated">Exportar Fontes</target>
+          <target state="translated">Exportar tipos de letra</target>
         </trans-unit>
         <trans-unit id="CollectionExportFolder.Text" translate="yes" xml:space="preserve">
           <source>To Folder</source>
-          <target state="translated">para a Pasta</target>
+          <target state="translated">Para a pasta</target>
         </trans-unit>
         <trans-unit id="CollectionExportHeader.Text" translate="yes" xml:space="preserve">
           <source>Export Fonts</source>
-          <target state="translated">Exportar Fontes</target>
+          <target state="translated">Exportar tipos de letra</target>
         </trans-unit>
         <trans-unit id="CollectionExportZip.Text" translate="yes" xml:space="preserve">
           <source>As Zip Archive</source>
-          <target state="translated">como Ficheiro Zip</target>
+          <target state="translated">Como pasta comprimida (zipada)</target>
         </trans-unit>
         <trans-unit id="SystemFontsExpiredMessage.Text" translate="yes" xml:space="preserve">
           <source>Font listings are out of date. Click to relaunch the app.</source>
-          <target state="translated">As listas das fontes estão desatualizadas. Clique para reiniciar a aplicação.</target>
-        </trans-unit>
-        <trans-unit id="TxtPathIcon.Text" translate="yes" xml:space="preserve">
-          <source>Path Icon</source>
-          <target state="translated">Path Icon</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">Xaml PathIcon. Does not need translation.</note>
+          <target state="translated">As listas dos tipos de letra estão desatualizadas. Premir para voltar a iniciar a aplicação.</target>
         </trans-unit>
         <trans-unit id="BtnToggleDev.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" translate="yes" xml:space="preserve">
           <source>Toggle Dev Utils</source>
-          <target state="translated">Trocar Utilitários de Desenvolvimento</target>
+          <target state="translated">Ativar/desativar ferramentas de programador</target>
+        </trans-unit>
+        <trans-unit id="TxtPathIcon.Text" translate="yes" xml:space="preserve">
+          <source>Path Icon</source>
+          <target state="new">Path Icon</target>
+          <note from="MultilingualBuild" annotates="source" priority="2">Xaml PathIcon. Does not need translation.</note>
         </trans-unit>
         <trans-unit id="OptionAllEmoji.Text" translate="yes" xml:space="preserve">
           <source>All Categories</source>
-          <target state="translated">Todas as Categorias</target>
+          <target state="translated">Todas as categorias</target>
         </trans-unit>
         <trans-unit id="OptionAllEmojiTitle.Text" translate="yes" xml:space="preserve">
           <source>All Emoji</source>
-          <target state="translated">Todos os Emojis</target>
+          <target state="translated">Todos os emojis</target>
         </trans-unit>
         <trans-unit id="OptionEmojiDingbats.Text" translate="yes" xml:space="preserve">
           <source>Dingbats</source>
@@ -949,19 +948,19 @@ Por favor, considere a possibilidade de colocar detalhes sobre este erro no GitH
         </trans-unit>
         <trans-unit id="OptionEmojiSymbols.Text" translate="yes" xml:space="preserve">
           <source>Symbols &amp; Pictographs</source>
-          <target state="translated">Símbolos &amp; Pictogramas</target>
+          <target state="translated">Símbolos &amp; pictogramas</target>
         </trans-unit>
         <trans-unit id="OptionScriptArabic.Text" translate="yes" xml:space="preserve">
           <source>Arabic</source>
-          <target state="translated">Arábico</target>
+          <target state="translated">Árabe</target>
         </trans-unit>
         <trans-unit id="OptionScriptBasicLatin.Text" translate="yes" xml:space="preserve">
           <source>Latin</source>
-          <target state="translated">Latin</target>
+          <target state="translated">Latim</target>
         </trans-unit>
         <trans-unit id="OptionScriptCJKUnifiedIdeographs.Text" translate="yes" xml:space="preserve">
-          <source>CJK</source>
-          <target state="translated">CJK</target>
+          <source>CJK (Chinese/Japanese/Korean)</source>
+          <target state="translated">CJK (Chinês/Japonês/Coreano)</target>
         </trans-unit>
         <trans-unit id="OptionScriptCyrillic.Text" translate="yes" xml:space="preserve">
           <source>Cyrillic</source>
@@ -981,15 +980,15 @@ Por favor, considere a possibilidade de colocar detalhes sobre este erro no GitH
         </trans-unit>
         <trans-unit id="CultureSpecificPangram.Text" translate="yes" xml:space="preserve">
           <source>How vexingly quick daft zebras jump! 1234567890</source>
-          <target state="translated">Já fiz vinho com toque de kiwi para belga sexy. 1234567890</target>
+          <target state="translated">Bancos fúteis pagavam-lhe queijo, whisky e xadrez. 1234567890</target>
         </trans-unit>
         <trans-unit id="LblSwitchToCharMap.Text" translate="yes" xml:space="preserve">
           <source>Switch to Character Map view (Ctrl+T)</source>
-          <target state="translated">Mudar para a Visualização Mapa de Carateres (Ctrl+T)</target>
+          <target state="translated">Mudar para a visualização Mapa de Carácter (Ctrl+T)</target>
         </trans-unit>
         <trans-unit id="LblSwitchToTypeRamp.Text" translate="yes" xml:space="preserve">
           <source>Switch to Type Ramp view (Ctrl+T)</source>
-          <target state="translated">Mudar para a Visualização Tipo Rampa (Ctrl+T)</target>
+          <target state="translated">Mudar para a visualização Rampa (Ctrl+T)</target>
         </trans-unit>
         <trans-unit id="TypeRampInputBox.PlaceholderText" translate="yes" xml:space="preserve">
           <source>Enter or choose text from the dropdown</source>
@@ -999,37 +998,29 @@ Por favor, considere a possibilidade de colocar detalhes sobre este erro no GitH
           <source>Exported to {0}</source>
           <target state="translated">Exportado para {0}</target>
         </trans-unit>
-        <trans-unit id="SettingsAboutLabel.Text" translate="yes" xml:space="preserve">
-          <source>About</source>
-          <target state="translated">Acerca de</target>
-        </trans-unit>
-        <trans-unit id="SettingsAdvancedUILabel.Text" translate="yes" xml:space="preserve">
-          <source>User Interface Advanced</source>
-          <target state="translated">Interface de Utilizador Avançado</target>
-        </trans-unit>
-        <trans-unit id="SettingsFontManagementLabel.Text" translate="yes" xml:space="preserve">
-          <source>Font Management</source>
-          <target state="translated">Gestão de Fontes</target>
-        </trans-unit>
-        <trans-unit id="SettingsLicensesLabel.Text" translate="yes" xml:space="preserve">
-          <source>Licenses</source>
-          <target state="translated">Licenças</target>
-        </trans-unit>
         <trans-unit id="ImportDragDropDescriptionLabel.Text" translate="yes" xml:space="preserve">
           <source>Drag files from File Explorer or your desktop and drop them here to import them.</source>
-          <target state="translated">Arraste os ficheiros do Explorador de Ficheiros ou do seu ambiente de trabalho e largue-os aqui para os importar.</target>
+          <target state="translated">Arraste ficheiros do Explorador de Ficheiros ou do seu ambiente de trabalho e largue-os aqui para importar.</target>
         </trans-unit>
         <trans-unit id="ImportDragDropLabel.Text" translate="yes" xml:space="preserve">
           <source>Drag and drop to import</source>
           <target state="translated">Arraste e largue para importar</target>
         </trans-unit>
+        <trans-unit id="SettingsAboutLabel.Text" translate="yes" xml:space="preserve">
+          <source>About</source>
+          <target state="translated">Acerca</target>
+        </trans-unit>
+        <trans-unit id="SettingsAdvancedUILabel.Text" translate="yes" xml:space="preserve">
+          <source>Look &amp; Feel</source>
+          <target state="translated">Aspeto &amp; Feel</target>
+        </trans-unit>
         <trans-unit id="SettingsExportImportedLabel.Text" translate="yes" xml:space="preserve">
           <source>Export all imported fonts</source>
-          <target state="translated">Exportar todas as fontes importadas</target>
+          <target state="translated">Exportar todos os tipos de letra importados</target>
         </trans-unit>
         <trans-unit id="SettingsFontExportOptimizedLabel.Text" translate="yes" xml:space="preserve">
           <source>Optimized</source>
-          <target state="translated">Otimizado</target>
+          <target state="translated">Optimizado</target>
         </trans-unit>
         <trans-unit id="SettingsFontExportSystemLabel.Text" translate="yes" xml:space="preserve">
           <source>System</source>
@@ -1039,107 +1030,115 @@ Por favor, considere a possibilidade de colocar detalhes sobre este erro no GitH
           <source>You can import fonts into the application to view them without installing them in Windows. 
 
 Imported font files are copied into the app's private storage, so will still show if you delete the original file on your computer.</source>
-          <target state="translated">Pode importar fontes para a aplicação para as visualizar sem as instalar no Windows. 
+          <target state="translated">Pode importar tipos de letra para os visualizar sem os instalar no Windows. 
 
-Os ficheiros de fontes importadas são copiados para o armazenamento privado da aplicação, pelo que continuará a aparecer se apagar o ficheiro original no seu computador.</target>
+Os ficheiros de tipo de letra importados são copiados para o armazenamento privado da aplicação, pelo que continuam a ser exibidos mesmo que elimine o ficheiro original no seu dispositivo.</target>
+        </trans-unit>
+        <trans-unit id="SettingsFontManagementLabel.Text" translate="yes" xml:space="preserve">
+          <source>Font Management</source>
+          <target state="translated">Gestão de tipos de letra</target>
         </trans-unit>
         <trans-unit id="SettingsFontNameExportDescription.Text" translate="yes" xml:space="preserve">
           <source>Choose how to name font files when exporting them.
 
 System will return the name of the font file Windows uses in uppercase.
 Optimized will create a smart name based on Font Family and Font Name.</source>
-          <target state="translated">Escolha como nomear os ficheiros da fonte quando os exportar.
+          <target state="translated">Escolhe como nomear os ficheiros de tipo de letra na exportação.
 
-O sistema devolverá o nome do ficheiro da fonte que o Windows usa em maiúsculas.
-Otimizado irá criar um nome inteligente baseado na Família da Fonte e no Nome da Fonte.</target>
+Sistema devolverá o nome do tipo de letra que o Windows utiliza em maiúsculas.
+Optimizado cria um nome inteligente baseado no nome da família e no nome do tipo de letra.</target>
         </trans-unit>
         <trans-unit id="SettingsFontNameExportLabel.Text" translate="yes" xml:space="preserve">
           <source>Font File Export Naming</source>
-          <target state="translated">Nomeação da Exportação de Ficheiros das Fontes</target>
+          <target state="translated">Nomenclatura da exportação dos ficheiros de tipo de letra</target>
         </trans-unit>
         <trans-unit id="SettingsImportedFontsLabel.Text" translate="yes" xml:space="preserve">
           <source>Imported Fonts</source>
-          <target state="translated">Fontes Importadas</target>
+          <target state="translated">Tipos de letra importados</target>
         </trans-unit>
         <trans-unit id="SettingsLicensesDescriptionLabel.Text" translate="yes" xml:space="preserve">
           <source>This application makes use of the following open source libraries</source>
-          <target state="translated">Esta aplicação faz uso das seguintes bibliotecas de código-fonte aberto</target>
+          <target state="translated">Esta aplicação utiliza as seguintes bibliotecas de código aberto</target>
         </trans-unit>
-        <trans-unit id="OptionVariableFonts.Text" translate="yes" xml:space="preserve">
-          <source>Variable Fonts</source>
-          <target state="translated">Fontes Variáveis</target>
-        </trans-unit>
-        <trans-unit id="VariableFeaturesMessage.Text" translate="yes" xml:space="preserve">
-          <source>This font has variable features. To explore them, switch to Type Ramp view using the switch button above.</source>
-          <target state="translated">Esta fonte tem caraterísticas variáveis. Para as explorar, mude para a vista Tipo Rampa utilizando o botão de troca acima.</target>
+        <trans-unit id="SettingsLicensesLabel.Text" translate="yes" xml:space="preserve">
+          <source>Licenses</source>
+          <target state="translated">Licenças</target>
         </trans-unit>
         <trans-unit id="BtnReset.Content" translate="yes" xml:space="preserve">
           <source>Reset</source>
           <target state="translated">Repor</target>
         </trans-unit>
+        <trans-unit id="OptionVariableFonts.Text" translate="yes" xml:space="preserve">
+          <source>Variable Fonts</source>
+          <target state="translated">Tipos de letra variável</target>
+        </trans-unit>
+        <trans-unit id="VariableFeaturesMessage.Text" translate="yes" xml:space="preserve">
+          <source>This font has variable features. To explore them, switch to Type Ramp view using the switch button above.</source>
+          <target state="translated">Este tipo de letra tem características variáveis. Para explorar as características, mude para a visualização Rampa utilizando o botão ativar/desativar acima.</target>
+        </trans-unit>
         <trans-unit id="SettingsEnablePaneDescription.Text" translate="yes" xml:space="preserve">
           <source>Shows or hides the preview pane on the right of the screen. If turned off, many functions can still be accessed by right clicking or touch holding on a character inside the character grid.</source>
-          <target state="translated">Mostra ou oculta o painel de pré-visualização no lado direito do ecrã. Se desativado, muitas funções ainda podem ser acedidas clicando com o botão direito do rato ou segurando o toque num carater dentro da grelha de carateres.</target>
+          <target state="translated">Mostra ou oculta o painel de pré-visualização no lado direito do ecrã. Se oculto, ainda pode aceder a algumas das funções ao clicar com o botão direito do rato ou tocar sem soltar no carácter dentro da grelha.</target>
         </trans-unit>
         <trans-unit id="SettingsEnablePaneHeader.Text" translate="yes" xml:space="preserve">
           <source>Preview Pane Display</source>
-          <target state="translated">Pré-visualização do Painel de Visualização</target>
+          <target state="translated">Visualização do painel de pré-visualização</target>
         </trans-unit>
         <trans-unit id="CopyFontIconCode.Text" translate="yes" xml:space="preserve">
           <source>Copy FontIcon Code</source>
-          <target state="translated">Copiar  FontIcon Code</target>
+          <target state="translated">Copiar código FontIcon</target>
         </trans-unit>
         <trans-unit id="CopyGlyphCode.Text" translate="yes" xml:space="preserve">
           <source>Copy Glyph Code</source>
-          <target state="translated">Copiar  Glyph Code</target>
+          <target state="translated">Copiar código do glifo</target>
         </trans-unit>
         <trans-unit id="CopyPathIconCode.Text" translate="yes" xml:space="preserve">
           <source>Copy PathIcon Code</source>
-          <target state="translated">Copiar  PathIcon Code</target>
+          <target state="translated">Copiar código PathIcon</target>
         </trans-unit>
         <trans-unit id="SearchBoxShorter" translate="yes" xml:space="preserve">
           <source>Search...</source>
-          <target state="translated">Pesquisar...</target>
+          <target state="translated">Procurar...</target>
         </trans-unit>
         <trans-unit id="CopyUnicodeValue.Text" translate="yes" xml:space="preserve">
           <source>Copy Unicode Value</source>
-          <target state="translated">Copiar Valor Unicode</target>
+          <target state="translated">Copiar valor Unicode</target>
         </trans-unit>
         <trans-unit id="DecreaseSizeButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" translate="yes" xml:space="preserve">
           <source>Decrease Character Size (Ctrl+-)</source>
-          <target state="translated">Diminuir o Tamanho do Carater (Ctrl+-)</target>
+          <target state="translated">Diminuir tamanho do carácter (Ctrl+-)</target>
         </trans-unit>
         <trans-unit id="IncreaseSizeButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" translate="yes" xml:space="preserve">
           <source>Increase Character Size (Ctrl++)</source>
-          <target state="translated">Aumentar o Tamanho do Carater (Ctrl++)</target>
+          <target state="translated">Aumentar tamanho do carácter (Ctrl++)</target>
         </trans-unit>
         <trans-unit id="SwitchViewButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" translate="yes" xml:space="preserve">
           <source>Switch View (Ctrl+T)</source>
-          <target state="translated">Trocar Visualização (Ctrl+T)</target>
+          <target state="translated">Mudar vista (Ctrl+T)</target>
         </trans-unit>
         <trans-unit id="TogglePaneButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" translate="yes" xml:space="preserve">
           <source>Toggle Preview Pane (Ctrl+R)</source>
-          <target state="translated">Trocar Painel de Pré-visualização (Ctrl+R)</target>
+          <target state="translated">Ativar/desativar painel de pré-visualização (Ctrl+R)</target>
         </trans-unit>
         <trans-unit id="NotificationCopied" translate="yes" xml:space="preserve">
           <source>Copied</source>
           <target state="translated">Copiado</target>
         </trans-unit>
-        <trans-unit id="ToggleCopyPaneButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" translate="yes" xml:space="preserve">
-          <source>Toggle Copy Pane (Ctrl+B)</source>
-          <target state="translated">Trocar Painel de Cópia (Ctrl+B)</target>
-        </trans-unit>
         <trans-unit id="AddButton.Label" translate="yes" xml:space="preserve">
           <source>Add</source>
           <target state="translated">Adicionar</target>
         </trans-unit>
-        <trans-unit id="CopySequencePlaceholder.Text" translate="yes" xml:space="preserve">
-          <source>double click a character or use the Add button</source>
-          <target state="translated">clique duas vezes em um carater ou utilize o botão Adicionar</target>
-        </trans-unit>
         <trans-unit id="AddSelectionItem.Text" translate="yes" xml:space="preserve">
           <source>Add to selection</source>
           <target state="translated">Adicionar à seleção</target>
+        </trans-unit>
+        <trans-unit id="CopySequencePlaceholder.Text" translate="yes" xml:space="preserve">
+          <source>double click a character or use the Add button</source>
+          <target state="translated">fazer duplo clique num carácter ou utilize o botão Adicionar</target>
+        </trans-unit>
+        <trans-unit id="ToggleCopyPaneButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" translate="yes" xml:space="preserve">
+          <source>Toggle Copy Pane (Ctrl+B)</source>
+          <target state="translated">Ativar/desativar painel de cópia (Ctrl+B)</target>
         </trans-unit>
         <trans-unit id="CompactOverlayButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" translate="yes" xml:space="preserve">
           <source>Keep on top</source>
@@ -1147,7 +1146,7 @@ Otimizado irá criar um nome inteligente baseado na Família da Fonte e no Nome 
         </trans-unit>
         <trans-unit id="TypographyVariationsSelectorRun.Text" translate="yes" xml:space="preserve">
           <source>Typography Variations</source>
-          <target state="translated">Variações Tipográficas</target>
+          <target state="translated">variações de tipografia</target>
         </trans-unit>
         <trans-unit id="ToggleDevDefaultLabel" translate="yes" xml:space="preserve">
           <source>Tools</source>
@@ -1155,25 +1154,25 @@ Otimizado irá criar um nome inteligente baseado na Família da Fonte e no Nome 
         </trans-unit>
         <trans-unit id="BtnFit.Label" translate="yes" xml:space="preserve">
           <source>Fit</source>
-          <target state="translated">Adaptar</target>
+          <target state="translated">Ajustar</target>
         </trans-unit>
         <trans-unit id="TxtCopiedVariantMessage.Text" translate="yes" xml:space="preserve">
           <source>Glyph variations cannot be copied.
 Default variant copied.</source>
-          <target state="translated">As variações do glyph não podem ser copiadas.
-Variante predefinida copiada.</target>
+          <target state="translated">Não é possível copiar variações de glifo.
+Foi copiada a variante predefinida.</target>
         </trans-unit>
         <trans-unit id="CollectionFontHelpBlock.Text" translate="yes" xml:space="preserve">
           <source>There are no fonts in this collection yet.</source>
-          <target state="translated">Ainda não existem fontes nesta coleção.</target>
+          <target state="translated">Ainda não existem tipos de letra nesta coleção.</target>
         </trans-unit>
         <trans-unit id="SearchFontHelpBlock.Text" translate="yes" xml:space="preserve">
           <source>No results found for this search. Try something else.</source>
-          <target state="translated">Não foram encontrados resultados para esta pesquisa. Tente outra coisa.</target>
+          <target state="translated">Não conseguimos encontrar o que procurava. Tente algo diferente.</target>
         </trans-unit>
         <trans-unit id="FontListSearchBox.PlaceholderText" translate="yes" xml:space="preserve">
           <source>Find a font family</source>
-          <target state="translated">Encontrar uma família de fontes</target>
+          <target state="translated">Localizar uma família tipográfica</target>
         </trans-unit>
         <trans-unit id="BtnToggleDev.Label" translate="yes" xml:space="preserve">
           <source>Tools</source>
@@ -1181,7 +1180,7 @@ Variante predefinida copiada.</target>
         </trans-unit>
         <trans-unit id="DevPopupHeader.Text" translate="yes" xml:space="preserve">
           <source>Show Developer Tools</source>
-          <target state="translated">Mostrar Ferramentas de Desenvolvedor</target>
+          <target state="translated">Mostrar ferramentas de programação</target>
         </trans-unit>
         <trans-unit id="ContextMenuDevCopyCommand" translate="yes" xml:space="preserve">
           <source>Copy {0}</source>
@@ -1194,96 +1193,1035 @@ Variante predefinida copiada.</target>
         </trans-unit>
         <trans-unit id="SettingsChangelogLabel.Text" translate="yes" xml:space="preserve">
           <source>Changelog</source>
-          <target state="translated">Registo de Alterações</target>
+          <target state="translated">Notas de versão</target>
         </trans-unit>
         <trans-unit id="TxtFontImageSource.Text" translate="yes" xml:space="preserve">
           <source>Font Image Source</source>
-          <target state="translated">Font Image Source</target>
+          <target state="new">Font Image Source</target>
           <note from="MultilingualBuild" annotates="source" priority="2">Xamarin FontImageSource. Does not need translation.</note>
         </trans-unit>
         <trans-unit id="ImportFailedWoff" translate="yes" xml:space="preserve">
           <source>WOFF font could not be converted to a valid OTF font.</source>
-          <target state="translated">A fonte WOFF não pôde ser convertida para uma fonte OTF válida.</target>
+          <target state="translated">Não foi possível converter o tipo de letra WOFF para um tipo de letra OTF válido.</target>
         </trans-unit>
         <trans-unit id="ImportWOFF2NotSupported" translate="yes" xml:space="preserve">
           <source>WOFF2 files are not supported</source>
-          <target state="translated">Os ficheiros WOFF2 não são suportados</target>
+          <target state="translated">Ficheiros WOFF2 não são suportados</target>
         </trans-unit>
         <trans-unit id="CharacterFilterButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" translate="yes" xml:space="preserve">
           <source>Filter Characters</source>
-          <target state="translated">Filtrar Carateres</target>
+          <target state="translated">Filtrar caracteres</target>
         </trans-unit>
         <trans-unit id="CompareFontsTitle.Text" translate="yes" xml:space="preserve">
           <source>Compare Fonts</source>
-          <target state="translated">Comparar Fontes</target>
+          <target state="translated">Comparar tipos de letra</target>
         </trans-unit>
         <trans-unit id="LayoutGridToggle.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" translate="yes" xml:space="preserve">
           <source>Grid Layout</source>
-          <target state="translated">Layout da Grelha</target>
+          <target state="translated">Esquema grelha</target>
         </trans-unit>
         <trans-unit id="LayoutListToggle.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" translate="yes" xml:space="preserve">
           <source>List Layout</source>
-          <target state="translated">Layout da Lista</target>
+          <target state="translated">Esquema lista</target>
         </trans-unit>
         <trans-unit id="QuickCompareTitle.Text" translate="yes" xml:space="preserve">
           <source>Quick Compare</source>
-          <target state="translated">Comparação Rápida</target>
+          <target state="translated">Comparação rápida</target>
         </trans-unit>
         <trans-unit id="AddToQuickCompare.Text" translate="yes" xml:space="preserve">
           <source>Add to quick compare</source>
-          <target state="translated">Adicionar para Comparação Rápida</target>
+          <target state="translated">Adicionar à comparação rápida</target>
         </trans-unit>
         <trans-unit id="CompareFontsButton.Text" translate="yes" xml:space="preserve">
           <source>Compare all Fonts</source>
-          <target state="translated">Comparar todas as Fontes</target>
+          <target state="translated">Comparar todos os tipos de letra</target>
         </trans-unit>
         <trans-unit id="BtnGithubCommits.Content" translate="yes" xml:space="preserve">
           <source>View the latest commits on Github</source>
-          <target state="translated">Veja os últimos commits no Github</target>
+          <target state="translated">Ver as revisões mais recentes no Github</target>
         </trans-unit>
         <trans-unit id="ExportGlyphsHeader.Text" translate="yes" xml:space="preserve">
           <source>Export Characters</source>
-          <target state="translated">Exportar Carateres</target>
+          <target state="translated">Exportar caracteres</target>
         </trans-unit>
         <trans-unit id="ExportGlyphsSummary.Text" translate="yes" xml:space="preserve">
           <source>Ready to export {0} characters as {1}</source>
-          <target state="translated">Pronto para exportar {0} carateres como {1}</target>
+          <target state="translated">Pronto para exportar {0} caracteres como {1}</target>
         </trans-unit>
         <trans-unit id="ExportCharactersLabel.Text" translate="yes" xml:space="preserve">
           <source>Export Characters</source>
-          <target state="translated">Exportar Carateres</target>
+          <target state="translated">Exportar caracteres</target>
         </trans-unit>
         <trans-unit id="ExportGlyphsResultMessage.Text" translate="yes" xml:space="preserve">
           <source>{0} characters exported</source>
-          <target state="translated">{0} carater(es) exportado(s)</target>
+          <target state="translated">{0} caracteres exportados</target>
         </trans-unit>
         <trans-unit id="ExportGlyphsProgressMessage.Text" translate="yes" xml:space="preserve">
           <source>Exporting character {0} of {1}</source>
-          <target state="translated">Exportando carater {0} de {1}</target>
+          <target state="translated">A exportar carácter {0} de {1}</target>
         </trans-unit>
         <trans-unit id="ExportAllowColor.Content" translate="yes" xml:space="preserve">
           <source>Allow font to use its own colors if defined</source>
-          <target state="translated">Permitir que a fonte utilize as suas próprias cores, se definidas</target>
+          <target state="translated">Permitir, se presentes, que o tipo de letra utilize as suas próprias cores</target>
         </trans-unit>
         <trans-unit id="ExportColorHeader.Text" translate="yes" xml:space="preserve">
           <source>Default Color</source>
-          <target state="translated">Cor Predefinida</target>
+          <target state="translated">Cor predefinida</target>
         </trans-unit>
         <trans-unit id="ExportGlyphFormatDescription.Text" translate="yes" xml:space="preserve">
           <source>Glyphs stored in binary formats will be exported as their native format regardless of this choice.</source>
-          <target state="translated">Os glyphs armazenados em formatos binários serão exportados como o seu formato nativo, independentemente desta escolha.</target>
+          <target state="translated">Os glifos armazenados em formato binário serão exportados no seu formato nativo, independentemente desta escolha.</target>
         </trans-unit>
         <trans-unit id="ExportGlyphSelectedCharacters.Text" translate="yes" xml:space="preserve">
           <source>{0} of {1} characters selected</source>
-          <target state="translated">{0} de {1} carateres selecionado(s)</target>
+          <target state="translated">{0} de {1} caracteres selecionados</target>
         </trans-unit>
         <trans-unit id="ExportFileOptionsHeader.Text" translate="yes" xml:space="preserve">
           <source>File Options</source>
-          <target state="translated">Opções de Ficheiros</target>
+          <target state="translated">Opções do ficheiro</target>
         </trans-unit>
         <trans-unit id="ExportSkipBlank.Content" translate="yes" xml:space="preserve">
           <source>Skip exporting glyphs with no visible content</source>
-          <target state="translated">Ignorar exportação de glyphs sem conteúdo visível</target>
+          <target state="translated">Ignorar a exportação de glifos sem conteúdo perceptível</target>
+        </trans-unit>
+        <trans-unit id="CharacterFilterButton.Label" translate="yes" xml:space="preserve">
+          <source>Filter</source>
+          <target state="translated">Filtrar</target>
+          <note from="MultilingualBuild" annotates="source" priority="2">Labels must be as short as possible</note>
+        </trans-unit>
+        <trans-unit id="CollectionExportButton.Label" translate="yes" xml:space="preserve">
+          <source>Export</source>
+          <target state="translated">Exportar</target>
+          <note from="MultilingualBuild" annotates="source" priority="2">Labels must be as short as possible</note>
+        </trans-unit>
+        <trans-unit id="DeleteCollectionButton.Label" translate="yes" xml:space="preserve">
+          <source>Delete</source>
+          <target state="translated">Eliminar</target>
+          <note from="MultilingualBuild" annotates="source" priority="2">Labels must be as short as possible</note>
+        </trans-unit>
+        <trans-unit id="FontOptionsButton.Label" translate="yes" xml:space="preserve">
+          <source>Options</source>
+          <target state="translated">Opções</target>
+          <note from="MultilingualBuild" annotates="source" priority="2">Labels must be as short as possible</note>
+        </trans-unit>
+        <trans-unit id="FontPropertiesButton.Label" translate="yes" xml:space="preserve">
+          <source>Info</source>
+          <target state="translated">Info</target>
+          <note from="MultilingualBuild" annotates="source" priority="2">Labels must be as short as possible</note>
+        </trans-unit>
+        <trans-unit id="OpenFontButton.Label" translate="yes" xml:space="preserve">
+          <source>Open</source>
+          <target state="translated">Abrir</target>
+          <note from="MultilingualBuild" annotates="source" priority="2">Labels must be as short as possible</note>
+        </trans-unit>
+        <trans-unit id="RenameCollectionButton.Label" translate="yes" xml:space="preserve">
+          <source>Rename</source>
+          <target state="translated">Renomear</target>
+          <note from="MultilingualBuild" annotates="source" priority="2">Labels must be as short as possible</note>
+        </trans-unit>
+        <trans-unit id="SettingsDesignStyle.Description" translate="yes" xml:space="preserve">
+          <source>Change the design style of the application.
+Requires a restart to take effect.</source>
+          <target state="translated">Alterar o estilo de desenho da aplicação.
+Verá a sua alteração quando voltar a iniciar a aplicação.</target>
+        </trans-unit>
+        <trans-unit id="SettingsDesignStyle.Title" translate="yes" xml:space="preserve">
+          <source>Design Style</source>
+          <target state="translated">Estilo de desenho</target>
+        </trans-unit>
+        <trans-unit id="ViewToggleButton.Label" translate="yes" xml:space="preserve">
+          <source>Switch</source>
+          <target state="translated">Mudar</target>
+          <note from="MultilingualBuild" annotates="source" priority="2">Labels must be as short as possible</note>
+        </trans-unit>
+        <trans-unit id="AddTooButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" translate="yes" xml:space="preserve">
+          <source>Add to Collection</source>
+          <target state="translated">Adicionar à coleção</target>
+        </trans-unit>
+        <trans-unit id="ClearSelectionLabel" translate="yes" xml:space="preserve">
+          <source>Clear selection</source>
+          <target state="translated">Limpar seleção</target>
+        </trans-unit>
+        <trans-unit id="CreateNewButton.Content" translate="yes" xml:space="preserve">
+          <source>Create New</source>
+          <target state="translated">Criar nova</target>
+        </trans-unit>
+        <trans-unit id="OrLabel.Text" translate="yes" xml:space="preserve">
+          <source>or</source>
+          <target state="translated">ou</target>
+        </trans-unit>
+        <trans-unit id="RemoveFromButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" translate="yes" xml:space="preserve">
+          <source>Remove from Collection</source>
+          <target state="translated">Remover da coleção</target>
+        </trans-unit>
+        <trans-unit id="SelectCollectionLabel" translate="yes" xml:space="preserve">
+          <source>Select Collection</source>
+          <target state="translated">Selecionar coleção</target>
+        </trans-unit>
+        <trans-unit id="SettingsCollectionsHeader" translate="yes" xml:space="preserve">
+          <source>Collections</source>
+          <target state="translated">Coleções</target>
+        </trans-unit>
+        <trans-unit id="DigOpenFolder.PrimaryButtonText" translate="yes" xml:space="preserve">
+          <source>Open Fonts</source>
+          <target state="translated">Abrir tipos de letra</target>
+        </trans-unit>
+        <trans-unit id="DigOpenFolder.SecondaryButtonText" translate="yes" xml:space="preserve">
+          <source>Cancel</source>
+          <target state="translated">Cancelar</target>
+        </trans-unit>
+        <trans-unit id="DigOpenFolder.Title" translate="yes" xml:space="preserve">
+          <source>Open Font Folder</source>
+          <target state="translated">Abrir pasta com tipos de letra</target>
+        </trans-unit>
+        <trans-unit id="DigOpenFolderContent.CheckRecursiveContent" translate="yes" xml:space="preserve">
+          <source>Look for fonts inside child folders</source>
+          <target state="translated">Incluir pastas subordinadas</target>
+        </trans-unit>
+        <trans-unit id="DigOpenFolderContent.CheckZipContent" translate="yes" xml:space="preserve">
+          <source>Look for fonts inside .ZIP archives</source>
+          <target state="translated">Incluir ficheiros comprimidos ZIP</target>
+        </trans-unit>
+        <trans-unit id="DigOpenFolderContent.FindDescription" translate="yes" xml:space="preserve">
+          <source>Enabling options may dramatically increase time required to open the folder</source>
+          <target state="translated">Ativar opções poder aumentar drasticamente o tempo necessário para abrir a pasta</target>
+        </trans-unit>
+        <trans-unit id="DigOpenFolderContent.FindHeader" translate="yes" xml:space="preserve">
+          <source>Find Options</source>
+          <target state="translated">Opções de procura</target>
+        </trans-unit>
+        <trans-unit id="DigOpenFolderContent.FindingFontsLabel" translate="yes" xml:space="preserve">
+          <source>Finding Fonts...</source>
+          <target state="translated">A procurar tipos de letra...</target>
+        </trans-unit>
+        <trans-unit id="DigOpenFolderContent.PrefixLabel" translate="yes" xml:space="preserve">
+          <source>Found</source>
+          <target state="translated">Encontrou</target>
+        </trans-unit>
+        <trans-unit id="DigOpenFolderContent.SelectHeader" translate="yes" xml:space="preserve">
+          <source>Selected Folder (click to change)</source>
+          <target state="translated">Pasta selecionada (premir para mudar)</target>
+        </trans-unit>
+        <trans-unit id="DigOpenFolderContent.SuffixLabel" translate="yes" xml:space="preserve">
+          <source>font files</source>
+          <target state="translated">ficheiro(s) de tipo de letra</target>
+        </trans-unit>
+        <trans-unit id="FontFileMenuItem.Text" translate="yes" xml:space="preserve">
+          <source>Open Font File</source>
+          <target state="translated">Abrir tipo de letra</target>
+        </trans-unit>
+        <trans-unit id="FontFolderMenuItem.Text" translate="yes" xml:space="preserve">
+          <source>Open Font Folder</source>
+          <target state="translated">Abrir pasta</target>
+        </trans-unit>
+        <trans-unit id="AddHistoryButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" translate="yes" xml:space="preserve">
+          <source>Add to history</source>
+          <target state="translated">Adicionar ao histórico</target>
+        </trans-unit>
+        <trans-unit id="CalligraphyLabel.Text" translate="yes" xml:space="preserve">
+          <source>Calligraphy</source>
+          <target state="translated">Caligrafia</target>
+        </trans-unit>
+        <trans-unit id="ClearAllButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" translate="yes" xml:space="preserve">
+          <source>Clear All</source>
+          <target state="translated">Limpar tudo</target>
+        </trans-unit>
+        <trans-unit id="ClearAllItem.Text" translate="yes" xml:space="preserve">
+          <source>Clear All</source>
+          <target state="translated">Limpar tudo</target>
+        </trans-unit>
+        <trans-unit id="GuideToggle.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" translate="yes" xml:space="preserve">
+          <source>Show Guide</source>
+          <target state="translated">Mostrar guias</target>
+        </trans-unit>
+        <trans-unit id="HistoryLabel.Text" translate="yes" xml:space="preserve">
+          <source>History</source>
+          <target state="translated">Histórico</target>
+        </trans-unit>
+        <trans-unit id="RedoButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" translate="yes" xml:space="preserve">
+          <source>Redo (Ctrl+Y)</source>
+          <target state="translated">Refazer (Ctrl+Y)</target>
+        </trans-unit>
+        <trans-unit id="RemoveButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" translate="yes" xml:space="preserve">
+          <source>Remove</source>
+          <target state="translated">Remover</target>
+        </trans-unit>
+        <trans-unit id="SaveButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" translate="yes" xml:space="preserve">
+          <source>Save (Ctrl+S)</source>
+          <target state="translated">Guardar (Ctrl+S)</target>
+        </trans-unit>
+        <trans-unit id="SideBySideToggle.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" translate="yes" xml:space="preserve">
+          <source>Side by side</source>
+          <target state="translated">Lado a lado</target>
+        </trans-unit>
+        <trans-unit id="UndoButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" translate="yes" xml:space="preserve">
+          <source>Undo (Ctrl+Z)</source>
+          <target state="translated">Anular (Ctrl+Z)</target>
+        </trans-unit>
+        <trans-unit id="GuideFontSlider.Header" translate="yes" xml:space="preserve">
+          <source>Guide Size</source>
+          <target state="translated">Tamanho da guia</target>
+        </trans-unit>
+        <trans-unit id="CharacterPickerButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" translate="yes" xml:space="preserve">
+          <source>Open Character Picker</source>
+          <target state="translated">Abrir seleccionador de caracteres</target>
+        </trans-unit>
+        <trans-unit id="GuideHeaderLabel.Text" translate="yes" xml:space="preserve">
+          <source>Guide Text</source>
+          <target state="translated">Texto da guia</target>
+        </trans-unit>
+        <trans-unit id="GuideSizeLabel.Text" translate="yes" xml:space="preserve">
+          <source>Guide Size</source>
+          <target state="translated">Tamanho da guia</target>
+        </trans-unit>
+        <trans-unit id="MenuToggle.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" translate="yes" xml:space="preserve">
+          <source>Show or Hide Font Pane (Ctrl+L)</source>
+          <target state="translated">Mostrar ou ocultar painel de tipos de letra (Ctrl+L)</target>
+        </trans-unit>
+        <trans-unit id="OpenInNewTab.Text" translate="yes" xml:space="preserve">
+          <source>Open in New Tab</source>
+          <target state="translated">Abrir num separador novo</target>
+        </trans-unit>
+        <trans-unit id="OptionScriptKorean.Text" translate="yes" xml:space="preserve">
+          <source>Korean</source>
+          <target state="translated">Coreano</target>
+        </trans-unit>
+        <trans-unit id="AddActiveToCollectionItem.Text" translate="yes" xml:space="preserve">
+          <source>Add active to Collection</source>
+          <target state="translated">Adicionar activos à Coleção</target>
+        </trans-unit>
+        <trans-unit id="CompareActiveItem.Text" translate="yes" xml:space="preserve">
+          <source>Compare active font faces</source>
+          <target state="translated">Comparar os tipos de letra activos</target>
+        </trans-unit>
+        <trans-unit id="OptionEmoji.Text" translate="yes" xml:space="preserve">
+          <source>Emoji</source>
+          <target state="translated">Emoji</target>
+        </trans-unit>
+        <trans-unit id="OptionSupportedScripts.Text" translate="yes" xml:space="preserve">
+          <source>Supported Scripts</source>
+          <target state="translated">Escritas suportadas</target>
+        </trans-unit>
+        <trans-unit id="CompareFontFaceTitle.Text" translate="yes" xml:space="preserve">
+          <source>Compare Font Faces</source>
+          <target state="translated">A comparar tipos de letra</target>
+        </trans-unit>
+        <trans-unit id="CompareFacesCountLabel.Text" translate="yes" xml:space="preserve">
+          <source>Compare {0} font faces</source>
+          <target state="translated">Comparar {0} tipos de letra</target>
+        </trans-unit>
+        <trans-unit id="CompareFamilyTitle.Text" translate="yes" xml:space="preserve">
+          <source>Compare {0}</source>
+          <target state="translated">A comparar {0}</target>
+        </trans-unit>
+        <trans-unit id="MenuButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" translate="yes" xml:space="preserve">
+          <source>Open Menu</source>
+          <target state="translated">Abrir menu</target>
+        </trans-unit>
+        <trans-unit id="FontsSelectedCountLabel" translate="yes" xml:space="preserve">
+          <source>{0} fonts, {1} selected</source>
+          <target state="translated">{0} tipo(s) de letra, {1} selecionado(s)</target>
+        </trans-unit>
+        <trans-unit id="CompareShortLabel" translate="yes" xml:space="preserve">
+          <source>Compare</source>
+          <target state="translated">Comparar</target>
+        </trans-unit>
+        <trans-unit id="AllFontsLabel.Text" translate="yes" xml:space="preserve">
+          <source>All Fonts</source>
+          <target state="translated">Todos os tipos de letra</target>
+        </trans-unit>
+        <trans-unit id="ImportLabel.Text" translate="yes" xml:space="preserve">
+          <source>Import</source>
+          <target state="translated">Importar</target>
+        </trans-unit>
+        <trans-unit id="PreferredFormatGroup.Text" translate="yes" xml:space="preserve">
+          <source>Preferred Format</source>
+          <target state="translated">Formato preferencial</target>
+          <note from="MultilingualBuild" annotates="source" priority="2">Preferred export format</note>
+        </trans-unit>
+        <trans-unit id="RemoveLabel.Text" translate="yes" xml:space="preserve">
+          <source>Remove</source>
+          <target state="translated">Remover</target>
+        </trans-unit>
+        <trans-unit id="UndoLabel" translate="yes" xml:space="preserve">
+          <source>Undo</source>
+          <target state="translated">Anular</target>
+        </trans-unit>
+        <trans-unit id="CalligraphyDescription.Text" translate="yes" xml:space="preserve">
+          <source>Practice writing in the style of the current font</source>
+          <target state="translated">Praticar a escrita no estilo do tipo de letra atual</target>
+        </trans-unit>
+        <trans-unit id="CompareFontsDescription.Text" translate="yes" xml:space="preserve">
+          <source>See and compare all your fonts side-by-side</source>
+          <target state="translated">Veja e compare todos os seus tipos de letra lado-a-lado</target>
+        </trans-unit>
+        <trans-unit id="DoMoreLabel.Text" translate="yes" xml:space="preserve">
+          <source>Do More</source>
+          <target state="translated">Efectuar mais</target>
+        </trans-unit>
+        <trans-unit id="FullscreenLabel.Text" translate="yes" xml:space="preserve">
+          <source>Fullscreen</source>
+          <target state="translated">Ecrã inteiro</target>
+        </trans-unit>
+        <trans-unit id="OpenFolderDescription.Text" translate="yes" xml:space="preserve">
+          <source>Open all font files found inside a folder</source>
+          <target state="translated">Abrir todos os tipos de letra dentro da pasta</target>
+        </trans-unit>
+        <trans-unit id="OpenFontDescription.Text" translate="yes" xml:space="preserve">
+          <source>Open TTF, OTF, OTC, TTC, WOFF, WOFF2 or ZIP files</source>
+          <target state="translated">Abrir ficheiros TTF, OTF, OTC, TTC, WOFF, WOFF2 ou ZIP</target>
+        </trans-unit>
+        <trans-unit id="SettingsPointerOverAnimation.Description" translate="yes" xml:space="preserve">
+          <source>Enables subtle bounce animations when the mouse pointer goes over certains buttons.</source>
+          <target state="translated">Ativa animações subtis de ressalto sempre que o ponteiro do rato passa sobre determinados botões.</target>
+        </trans-unit>
+        <trans-unit id="SettingsPointerOverAnimation.Title" translate="yes" xml:space="preserve">
+          <source>Enable pointer over animations</source>
+          <target state="translated">Animções sob o ponteiro do rato</target>
+        </trans-unit>
+        <trans-unit id="SettingsCustomSuggestions.Description" translate="yes" xml:space="preserve">
+          <source>Add and manage custom options to show in Type Ramp view and Comparison window text suggestions.
+Tap and hold to arrange.</source>
+          <target state="translated">Adiciona e organiza sugestões de texto personalizadas para mostrar na visualização Rampa e na janela de Comparação.
+Tocar e manter premido para organizar.</target>
+        </trans-unit>
+        <trans-unit id="SettingsCustomSuggestions.Title" translate="yes" xml:space="preserve">
+          <source>Custom Options</source>
+          <target state="translated">Opções personalizadas</target>
+        </trans-unit>
+        <trans-unit id="SettingsSuggestionsHeader.Text" translate="yes" xml:space="preserve">
+          <source>Preview Suggestions</source>
+          <target state="translated">Pré-visualizar sugestões</target>
+        </trans-unit>
+        <trans-unit id="SettingsSuggestionTextBox.PlaceholderText" translate="yes" xml:space="preserve">
+          <source>Enter your suggestion here</source>
+          <target state="translated">Introduz a tua sugestão aqui</target>
+        </trans-unit>
+        <trans-unit id="FontPropPanoseTitle.Text" translate="yes" xml:space="preserve">
+          <source>PANOSE Values</source>
+          <target state="translated">Valores PANOSE</target>
+        </trans-unit>
+        <trans-unit id="CharacterGroupingToggle.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" translate="yes" xml:space="preserve">
+          <source>Group Characters by Unicode Range (Ctrl+G)</source>
+          <target state="translated">Agrupar caracteres por intervalo de Unicode (Ctrl+G)</target>
+        </trans-unit>
+        <trans-unit id="PixelUnits.Text" translate="yes" xml:space="preserve">
+          <source>px</source>
+          <target state="translated">px</target>
+        </trans-unit>
+        <trans-unit id="SettingsCharGrouping.Description" translate="yes" xml:space="preserve">
+          <source>If enabled, characters are grouped by Unicode range in the character map, otherwise all characters are shown in a single ungrouped list.</source>
+          <target state="translated">Se estiver ativado, os caracteres são agrupados por intervalo de Unicode no mapa de caracteres, caso contrário eles são mostrados numa única lista desagrupada.</target>
+        </trans-unit>
+        <trans-unit id="SettingsCharGrouping.Title" translate="yes" xml:space="preserve">
+          <source>Character Grouping</source>
+          <target state="translated">Agrupar caracteres</target>
+        </trans-unit>
+        <trans-unit id="CopyAsImageItem.Text" translate="yes" xml:space="preserve">
+          <source>Copy as image</source>
+          <target state="translated">Copiar como imagem</target>
+        </trans-unit>
+        <trans-unit id="CopyAsPngItem.Text" translate="yes" xml:space="preserve">
+          <source>Copy as PNG</source>
+          <target state="translated">Copiar como PNG</target>
+        </trans-unit>
+        <trans-unit id="CopyAsSvgItem.Text" translate="yes" xml:space="preserve">
+          <source>Copy as SVG</source>
+          <target state="translated">Copiar como SVG</target>
+        </trans-unit>
+        <trans-unit id="NotificationCopiedPNG" translate="yes" xml:space="preserve">
+          <source>Copied as PNG</source>
+          <target state="translated">Copiado como PNG</target>
+        </trans-unit>
+        <trans-unit id="NotificationCopiedSVG" translate="yes" xml:space="preserve">
+          <source>Copied as SVG</source>
+          <target state="translated">Copiado como SVG</target>
+        </trans-unit>
+        <trans-unit id="ColrV1SupportMessage.Text" translate="yes" xml:space="preserve">
+          <source>This font contains COLRv1 glyphs. To preview them with proper rendering support, switch to Type Ramp view using the switch button above.</source>
+          <target state="translated">Este tipo de letra contém glifos COLRv1. Para os pré-visualizar com a composição adequada, mude para a visualização Rampa utilizando o botão acima.</target>
+        </trans-unit>
+        <trans-unit id="FontPropCOLRVersion.Text" translate="yes" xml:space="preserve">
+          <source>COLR Version</source>
+          <target state="translated">Versão COLR</target>
+        </trans-unit>
+        <trans-unit id="FontPropColourFormats.Text" translate="yes" xml:space="preserve">
+          <source>Color Glyph Formats</source>
+          <target state="translated">Formatos de glifos coloridos</target>
+        </trans-unit>
+        <trans-unit id="GlyphTypeBitmap" translate="yes" xml:space="preserve">
+          <source>Bitmap</source>
+          <target state="translated">Mapa de bits</target>
+        </trans-unit>
+        <trans-unit id="TypeRampFlowButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" translate="yes" xml:space="preserve">
+          <source>Change flow direction</source>
+          <target state="translated">Alterar sentido do fluxo</target>
+        </trans-unit>
+        <trans-unit id="TxtUniCodepoint.Header" translate="yes" xml:space="preserve">
+          <source>Unicode Codepoint</source>
+          <target state="translated">Ponto de código Unicode</target>
+        </trans-unit>
+        <trans-unit id="TxtUTF16.Header" translate="yes" xml:space="preserve">
+          <source>UTF-16 Value</source>
+          <target state="translated">Valor UTF-16</target>
+        </trans-unit>
+        <trans-unit id="EditSuggestionsItem.Text" translate="yes" xml:space="preserve">
+          <source>Edit Suggestions</source>
+          <target state="translated">Editar sugestões</target>
+        </trans-unit>
+        <trans-unit id="OptionScriptHiraganaAndKatakana.Text" translate="yes" xml:space="preserve">
+          <source>Hiragana &amp; Katakana</source>
+          <target state="translated">Hiragana &amp; Katakana</target>
+        </trans-unit>
+        <trans-unit id="OptionsScriptBengali.Text" translate="yes" xml:space="preserve">
+          <source>Bengali</source>
+          <target state="translated">Bangla</target>
+        </trans-unit>
+        <trans-unit id="OptionsScriptDevanagari.Text" translate="yes" xml:space="preserve">
+          <source>Devanagari</source>
+          <target state="translated">Devanágari</target>
+        </trans-unit>
+        <trans-unit id="BtnTextClose.Content" translate="yes" xml:space="preserve">
+          <source>Close</source>
+          <target state="translated">Fechar</target>
+        </trans-unit>
+        <trans-unit id="EditSuggestionsLabel.Text" translate="yes" xml:space="preserve">
+          <source>Edit Custom Suggestions</source>
+          <target state="translated">Editar sugestões personalizadas</target>
+        </trans-unit>
+        <trans-unit id="ShowSuggestionsButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" translate="yes" xml:space="preserve">
+          <source>Show Suggestions</source>
+          <target state="translated">Mostrar sugestões</target>
+        </trans-unit>
+        <trans-unit id="SuggestOptionArabic.Text" translate="yes" xml:space="preserve">
+          <source>Arabic</source>
+          <target state="translated">Árabe</target>
+        </trans-unit>
+        <trans-unit id="SuggestOptionBengali.Text" translate="yes" xml:space="preserve">
+          <source>Bengali</source>
+          <target state="translated">Bangla</target>
+        </trans-unit>
+        <trans-unit id="SuggestOptionBulgarian.Text" translate="yes" xml:space="preserve">
+          <source>Bulgarian</source>
+          <target state="translated">Búlgaro</target>
+        </trans-unit>
+        <trans-unit id="SuggestOptionChineseTraditional.Text" translate="yes" xml:space="preserve">
+          <source>Chinese (Traditional)</source>
+          <target state="translated">Chinês (Tradicional)</target>
+        </trans-unit>
+        <trans-unit id="SuggestOptionCultureSpecific.Text" translate="yes" xml:space="preserve">
+          <source>English</source>
+          <target state="translated">Português</target>
+        </trans-unit>
+        <trans-unit id="SuggestOptionCustom.Text" translate="yes" xml:space="preserve">
+          <source>Custom</source>
+          <target state="translated">Personalizada</target>
+        </trans-unit>
+        <trans-unit id="SuggestOptionCyrillicAlpha.Text" translate="yes" xml:space="preserve">
+          <source>Cyrillic Alphabet</source>
+          <target state="translated">Alfabeto cirílico</target>
+        </trans-unit>
+        <trans-unit id="SuggestOptionEmoji.Text" translate="yes" xml:space="preserve">
+          <source>Emoji</source>
+          <target state="translated">Emoji</target>
+        </trans-unit>
+        <trans-unit id="SuggestOptionEnglish.Text" translate="yes" xml:space="preserve">
+          <source>English</source>
+          <target state="translated">Inglês</target>
+        </trans-unit>
+        <trans-unit id="SuggestOptionGreek.Text" translate="yes" xml:space="preserve">
+          <source>Greek</source>
+          <target state="translated">Grego</target>
+        </trans-unit>
+        <trans-unit id="SuggestOptionHebrew.Text" translate="yes" xml:space="preserve">
+          <source>Hebrew</source>
+          <target state="translated">Hebraico</target>
+        </trans-unit>
+        <trans-unit id="SuggestOptionHindi.Text" translate="yes" xml:space="preserve">
+          <source>Hindi</source>
+          <target state="translated">Hindi</target>
+        </trans-unit>
+        <trans-unit id="SuggestOptionJapanese.Text" translate="yes" xml:space="preserve">
+          <source>Japanese</source>
+          <target state="translated">Japonês</target>
+        </trans-unit>
+        <trans-unit id="SuggestOptionKorean.Text" translate="yes" xml:space="preserve">
+          <source>Korean</source>
+          <target state="translated">Coreano</target>
+        </trans-unit>
+        <trans-unit id="SuggestOptionLatinAlpha.Text" translate="yes" xml:space="preserve">
+          <source>Latin Alphabet</source>
+          <target state="translated">Alfabeto latim</target>
+        </trans-unit>
+        <trans-unit id="SuggestOptionLatinSymbols.Text" translate="yes" xml:space="preserve">
+          <source>Latin Numbers &amp; Symbols</source>
+          <target state="translated">Números &amp; símbolos latim</target>
+        </trans-unit>
+        <trans-unit id="SuggestOptionSample.Text" translate="yes" xml:space="preserve">
+          <source>Font Sample Text</source>
+          <target state="translated">Texto de exemplo do tipo de letra</target>
+        </trans-unit>
+        <trans-unit id="SuggestOptionThai.Text" translate="yes" xml:space="preserve">
+          <source>Thai</source>
+          <target state="translated">Tailandês</target>
+        </trans-unit>
+        <trans-unit id="SuggestOptionVietnamese.Text" translate="yes" xml:space="preserve">
+          <source>Vietnamese</source>
+          <target state="translated">Vietnamita</target>
+        </trans-unit>
+        <trans-unit id="InstallCountLabel" translate="yes" xml:space="preserve">
+          <source>{0} Font Families, {1} Font Faces installed on your computer</source>
+          <target state="translated">{0} famílias tipográficas, {1} tipos de letra instalados no seu computador</target>
+        </trans-unit>
+        <trans-unit id="OptionSystemFonts.Text" translate="yes" xml:space="preserve">
+          <source>Installed Fonts</source>
+          <target state="translated">Tipos de letra instalados</target>
+        </trans-unit>
+        <trans-unit id="SettingsExportInstalledLabel.Text" translate="yes" xml:space="preserve">
+          <source>Export installed fonts</source>
+          <target state="translated">Exportar tipos de letra instalados</target>
+        </trans-unit>
+        <trans-unit id="OptionDesignTag.Text" translate="yes" xml:space="preserve">
+          <source>By Design Language</source>
+          <target state="new">By Design Language</target>
+        </trans-unit>
+        <trans-unit id="HiddenGlyphsMessage.Text" translate="yes" xml:space="preserve">
+          <source>Deprecated icon glyphs are hidden by default based on your settings. You can show them using the filter button above.</source>
+          <target state="translated">Com base nas suas definições, os ícones preteridos estão ocultos por predefinição. Utiliza o botão de filtro acima para os mostrar.</target>
+        </trans-unit>
+        <trans-unit id="InstallDialog.SecondaryButtonText" translate="yes" xml:space="preserve">
+          <source>Close</source>
+          <target state="translated">Fechar</target>
+        </trans-unit>
+        <trans-unit id="InstallDialog.Title" translate="yes" xml:space="preserve">
+          <source>Install Font</source>
+          <target state="translated">Instalar tipo de letra</target>
+        </trans-unit>
+        <trans-unit id="InstallFontInstructions.Text" translate="yes" xml:space="preserve">
+          <source>Please read all of instructions before continuing to install your font
+
+1. Press "Start" below
+2. Select "Windows Font Viewer" and choose "Just once" or "open"
+3. Press "Install" in the top of the font viewer Window
+
+Your web font will be converted to OTF format for installation.</source>
+          <target state="translated">Leia todas as instruções antes de continuar com a instalação do tipo de letra
+
+1. Prima "Iniciar" abaixo
+2. Selecione "Visual. Letras Windows" e escolha "Apenas uma vez"
+3. Prima "Instalar" na parte superior da janela do visualizador de letras
+
+O tipo de letra da Web será convertida num formato OTF para a instalação.</target>
+          <note from="MultilingualBuild" annotates="source" priority="2">Word in such a way that encourages the user to read all the steps before continuing</note>
+        </trans-unit>
+        <trans-unit id="InstallLabel.Text" translate="yes" xml:space="preserve">
+          <source>Install</source>
+          <target state="translated">Instalar</target>
+        </trans-unit>
+        <trans-unit id="OptionUnicodeRange/Text" translate="yes" xml:space="preserve">
+          <source>By Unicode Range</source>
+          <target state="translated">Por intervalo Unicode</target>
+        </trans-unit>
+        <trans-unit id="SettingsAdvancedOptionsLabel.Text" translate="yes" xml:space="preserve">
+          <source>Advanced</source>
+          <target state="translated">Avançado</target>
+        </trans-unit>
+        <trans-unit id="SettingsDeprecatedIconsPresenter.Description" translate="yes" xml:space="preserve">
+          <source>If enabled, hides deprecated icons in Segoe MDL2 and Segoe Fluent Icon fonts by default. Icons can still be shown using the filter flyout.
+
+Referencing deprecated icons by unicode codepoint is not recommended, and all deprecated icons have non-deprecated equivalents.</source>
+          <target state="translated">Se estiver ativado, oculta os ícones preteridos dos tipos de letra Segoe MDL2 e Segoe Fluent por predefinição. Os ícones ainda podem ser mostrados ao utilizar o filtro na lista de opções.
+
+Não é recomendado referenciar os ícones preteridos através do código unicode, todos os ícones preteridos tem um equivalente não preterido.</target>
+        </trans-unit>
+        <trans-unit id="SettingsDeprecatedIconsPresenter.Title" translate="yes" xml:space="preserve">
+          <source>Hide deprecated icons</source>
+          <target state="translated">Esconder ícones preteridos</target>
+        </trans-unit>
+        <trans-unit id="StartLabel.Text" translate="yes" xml:space="preserve">
+          <source>Start</source>
+          <target state="translated">Iniciar</target>
+        </trans-unit>
+        <trans-unit id="TxtUniHexValue.Text" translate="yes" xml:space="preserve">
+          <source>Hex Value</source>
+          <target state="translated">Valor hexadecimal</target>
+        </trans-unit>
+        <trans-unit id="FileExplorerFileToolTip" translate="yes" xml:space="preserve">
+          <source>Preview File</source>
+          <target state="translated">Pré-visualizar ficheiro</target>
+        </trans-unit>
+        <trans-unit id="ImportCountLabel" translate="yes" xml:space="preserve">
+          <source>{0} Font Families, {1} Font Faces imported</source>
+          <target state="translated">{0} família(s) tipográfica(s), {1} tipo(s) de letra importado(s)</target>
+        </trans-unit>
+        <trans-unit id="SettingsFontExportVersionLabel.Text" translate="yes" xml:space="preserve">
+          <source>Include version number in file name</source>
+          <target state="translated">Incluir número da versão no nome do ficheiro</target>
+        </trans-unit>
+        <trans-unit id="HideUnihanLabel.Text" translate="yes" xml:space="preserve">
+          <source>Hide Unihan data</source>
+          <target state="translated">Ocultar dados Unihan</target>
+        </trans-unit>
+        <trans-unit id="ShowUnihanLabel.Text" translate="yes" xml:space="preserve">
+          <source>Show Unihan data</source>
+          <target state="translated">Mostrar dados Unihan</target>
+        </trans-unit>
+        <trans-unit id="UnihanDefinition.Text" translate="yes" xml:space="preserve">
+          <source>Definition</source>
+          <target state="translated">Definição</target>
+        </trans-unit>
+        <trans-unit id="UnihanPronunciations.Text" translate="yes" xml:space="preserve">
+          <source>Pronunciations</source>
+          <target state="translated">Pronunciações</target>
+        </trans-unit>
+        <trans-unit id="UnihanTypeDescriptionCantonese" translate="yes" xml:space="preserve">
+          <source>The most customary jyutping (Cantonese) reading for this ideograph.</source>
+          <target state="translated">A leitura mais frequente em jyutping (cantonês) para este ideograma.</target>
+        </trans-unit>
+        <trans-unit id="UnihanTypeDescriptionHangul" translate="yes" xml:space="preserve">
+          <source>The modern Korean pronunciation(s) for this ideograph in Hangul, with its source(s) in brackets.</source>
+          <target state="translated">Pronúncia(s) de coreano moderno deste ideograma em hangul, com a(s) sua(s) fonte(s) entre parênteses.</target>
+        </trans-unit>
+        <trans-unit id="UnihanTypeDescriptionHanyuPinlu" translate="yes" xml:space="preserve">
+          <source>The Pronunciations and Frequencies of this ideograph, based in part on those appearing in 《現代漢語頻率詞典》 <it id="1" pos="open">&lt;Xiandai Hanyu Pinlu Cidian&gt;</it></source>
+          <target state="translated">Pronúncia(s) e frequência(s) deste ideograma, em parte com base em aparecerem no 《現代漢語頻率詞典》 <it id="1" pos="open">&lt;Xiandai Hanyu Pinlu Cidian&gt;</it></target>
+        </trans-unit>
+        <trans-unit id="UnihanTypeDescriptionHanyuPinyin" translate="yes" xml:space="preserve">
+          <source>The 漢語拼音 Hànyǔ Pīnyīn reading(s) appearing in the edition of 《漢語大字典》 Hànyǔ Dà Zìdiǎn (HDZ) specified in the kHanYu property description (q.v.).</source>
+          <target state="new">The 漢語拼音 Hànyǔ Pīnyīn reading(s) appearing in the edition of 《漢語大字典》 Hànyǔ Dà Zìdiǎn (HDZ) specified in the kHanYu property description (q.v.).</target>
+        </trans-unit>
+        <trans-unit id="UnihanTypeDescriptionJapanese" translate="yes" xml:space="preserve">
+          <source>The Japanese readings(s) for this ideograph expressed in Kana. 
+
+Readings expressed in Hiragana are generally considered Kun-yomi (訓読み), and readings expressed in Katakana are generally considered On-yomi (音読み).</source>
+          <target state="translated">A leitura deste ideograma, expressa em Kana, em japonês. 
+
+As leituras expressas em hiragana são, geralmente, consideradas Kun-yomi (訓読み), e as expressas em katakana são, geralmente, consideradas On-yomi (音読み).</target>
+        </trans-unit>
+        <trans-unit id="UnihanTypeDescriptionJapaneseKun" translate="yes" xml:space="preserve">
+          <source>The Japanese pronunciation(s) of this ideograph in the Hepburn romanization.</source>
+          <target state="translated">Pronúncia(s) de japonês para este ideograma na romanização Hepburn.</target>
+        </trans-unit>
+        <trans-unit id="UnihanTypeDescriptionJapaneseOn" translate="yes" xml:space="preserve">
+          <source>The Sino-Japanese pronunciation(s) of this ideograph.</source>
+          <target state="translated">Pronúncia(s) de sino-japonês para este ideograma.</target>
+        </trans-unit>
+        <trans-unit id="UnihanTypeDescriptionKorean" translate="yes" xml:space="preserve">
+          <source>The Korean pronunciation(s) of this ideograph, using the Yale romanization system.</source>
+          <target state="translated">Pronúncia(s) do ideograma em coreano, utilizando o sistema de romanização de Yale.</target>
+        </trans-unit>
+        <trans-unit id="UnihanTypeDescriptionMandarin" translate="yes" xml:space="preserve">
+          <source>The most customary pīnyīn reading for this ideograph. 
+
+When there are two values, then the first is preferred for Simplified Chinese (zh-Hans (CN)) and the second is preferred for Traditional Chinese (zh-Hant (TW)). 
+
+When there is only one value, it is appropriate for both.</source>
+          <target state="translated">A leitura mais frequente deste ideograma em pīnyīn. 
+
+Assim que existir dois valores, o chinês simplificado (zh-Hans (CN)) é o primeiro valor preferido seguido do chinês tradicional (zh-Hant (TW)). 
+
+Quando existe apenas um valor, ele é adequado para ambos.</target>
+        </trans-unit>
+        <trans-unit id="UnihanTypeDescriptionSMSZD2003Readings" translate="yes" xml:space="preserve">
+          <source>This represents the Mandarin and Cantonese readings(s) of the ideograph in the Soengmou San Zidin (商務 新字典, New Commercial Press Character Dictionary).
+
+Mandarin readings are in hànyǔ pīnyīn. Cantonese readings are in jyutping. Note that some ideographs have readings which would ordinarily be considered invalid, such as polysyllabic readings.
+
+If an ideograph has multiple entries, it means that the ideograph has multiple definitions and the readings are grouped in order of those definitions.</source>
+          <target state="new">This represents the Mandarin and Cantonese readings(s) of the ideograph in the Soengmou San Zidin (商務 新字典, New Commercial Press Character Dictionary).
+
+Mandarin readings are in hànyǔ pīnyīn. Cantonese readings are in jyutping. Note that some ideographs have readings which would ordinarily be considered invalid, such as polysyllabic readings.
+
+If an ideograph has multiple entries, it means that the ideograph has multiple definitions and the readings are grouped in order of those definitions.</target>
+        </trans-unit>
+        <trans-unit id="UnihanTypeDescriptionTang" translate="yes" xml:space="preserve">
+          <source>The Tang dynasty pronunciation(s) of this ideograph, derived from or consistent with T’ang Poetic Vocabulary by Hugh M. Stimson, Far Eastern Publications, Yale University 1976.</source>
+          <target state="translated">A(s) pronúncia(s) deste ideograma na dinastia Tang, derivada ou consistente com o T’ang Poetic Vocabulary por Hugh M. Stimson, Far Eastern Publications, Yale University 1976.</target>
+        </trans-unit>
+        <trans-unit id="UnihanTypeDescriptionTGHZ2013" translate="yes" xml:space="preserve">
+          <source>One or more Hànyǔ Pīnyīn readings as given in Tōngyòng Guīfàn Hànzì Zìdiǎn.</source>
+          <target state="translated">Uma ou mais leituras de Hànyǔ Pīnyīn conforme indicado no Tōngyòng Guīfàn Hànzì Zìdiǎn.</target>
+        </trans-unit>
+        <trans-unit id="UnihanTypeDescriptionVietnamese" translate="yes" xml:space="preserve">
+          <source>The ideograph’s pronunciation(s) in Quốc ngữ.</source>
+          <target state="translated">Pronúncia(s) do ideograma em Quốc ngữ.</target>
+        </trans-unit>
+        <trans-unit id="UnihanTypeDescriptionXHC1983" translate="yes" xml:space="preserve">
+          <source>One or more Hànyǔ Pīnyīn readings as given in the Xiàndài Hànyǔ Cídiǎn</source>
+          <target state="translated">Uma ou mais leituras de Hànyǔ Pīnyīn conforme indicado no Xiàndài Hànyǔ Cídiǎn</target>
+        </trans-unit>
+        <trans-unit id="UnihanTypeNameCantonese" translate="yes" xml:space="preserve">
+          <source>Cantonese</source>
+          <target state="translated">Cantonês</target>
+        </trans-unit>
+        <trans-unit id="UnihanTypeNameHangul" translate="yes" xml:space="preserve">
+          <source>Hangul</source>
+          <target state="translated">Hangul</target>
+        </trans-unit>
+        <trans-unit id="UnihanTypeNameHanyuPinlu" translate="yes" xml:space="preserve">
+          <source>Hanyu Pinlu</source>
+          <target state="new">Hanyu Pinlu</target>
+        </trans-unit>
+        <trans-unit id="UnihanTypeNameHanyuPinyin" translate="yes" xml:space="preserve">
+          <source>Hànyǔ Pīnyīn</source>
+          <target state="new">Hànyǔ Pīnyīn</target>
+        </trans-unit>
+        <trans-unit id="UnihanTypeNameJapanese" translate="yes" xml:space="preserve">
+          <source>Japanese</source>
+          <target state="translated">Japonês</target>
+        </trans-unit>
+        <trans-unit id="UnihanTypeNameJapaneseKun" translate="yes" xml:space="preserve">
+          <source>Japanese Kun</source>
+          <target state="translated">Japonês Kun</target>
+        </trans-unit>
+        <trans-unit id="UnihanTypeNameJapaneseOn" translate="yes" xml:space="preserve">
+          <source>Japanese On</source>
+          <target state="translated">Japonês On</target>
+        </trans-unit>
+        <trans-unit id="UnihanTypeNameKorean" translate="yes" xml:space="preserve">
+          <source>Korean</source>
+          <target state="translated">Coreano</target>
+        </trans-unit>
+        <trans-unit id="UnihanTypeNameMandarin" translate="yes" xml:space="preserve">
+          <source>Mandarin</source>
+          <target state="translated">Mandarim</target>
+        </trans-unit>
+        <trans-unit id="UnihanTypeNameSMSZD2003Readings" translate="yes" xml:space="preserve">
+          <source>SmSZ</source>
+          <target state="new">SmSZ</target>
+        </trans-unit>
+        <trans-unit id="UnihanTypeNameTang" translate="yes" xml:space="preserve">
+          <source>Tang</source>
+          <target state="new">Tang</target>
+        </trans-unit>
+        <trans-unit id="UnihanTypeNameTGHZ2013" translate="yes" xml:space="preserve">
+          <source>Hànyǔ Pīnyīn (TGHZ)</source>
+          <target state="new">Hànyǔ Pīnyīn (TGHZ)</target>
+        </trans-unit>
+        <trans-unit id="UnihanTypeNameVietnamese" translate="yes" xml:space="preserve">
+          <source>Vietnamese</source>
+          <target state="translated">Vietnamita</target>
+        </trans-unit>
+        <trans-unit id="UnihanTypeNameXHC1983" translate="yes" xml:space="preserve">
+          <source>Hànyǔ Pīnyīn (XHC)</source>
+          <target state="new">Hànyǔ Pīnyīn (XHC)</target>
+        </trans-unit>
+        <trans-unit id="HiddenSearchResultsLabel.Text" translate="yes" xml:space="preserve">
+          <source>HIDDEN</source>
+          <target state="translated">OCULTO</target>
+        </trans-unit>
+        <trans-unit id="NotificationSearchSelectedCharHidden" translate="yes" xml:space="preserve">
+          <source>The selected character is currently hidden by your selected filters</source>
+          <target state="translated">O carácter selecionado está atualmente oculto pelo seu filtro selecionado</target>
+        </trans-unit>
+        <trans-unit id="SuggestOptionChineseSimplified.Text" translate="yes" xml:space="preserve">
+          <source>Chinese (Simplified)</source>
+          <target state="translated">Chinês (Simplificado)</target>
+        </trans-unit>
+        <trans-unit id="CanvasFontInformationDesignScriptLanguageTag" translate="yes" xml:space="preserve">
+          <source>Designed Languages</source>
+          <target state="new">Designed Languages</target>
+        </trans-unit>
+        <trans-unit id="CollectionManagementHint.Text" translate="yes" xml:space="preserve">
+          <source>Create collections to compare, export or manage multiple fonts at once. To get started, select an existing collection above or create a new one.</source>
+          <target state="translated">Cria coleções para comparar, exportar ou gerir vários tipos de letra de uma só vez. Para começar, acima selecione uma coleção existente ou crie uma nova.</target>
+        </trans-unit>
+        <trans-unit id="CollectionSelector.PlaceholderText" translate="yes" xml:space="preserve">
+          <source>Choose existing</source>
+          <target state="translated">Escolher existente</target>
+        </trans-unit>
+        <trans-unit id="FindCharButton.Text" translate="yes" xml:space="preserve">
+          <source>Find in other fonts</source>
+          <target state="translated">Procurar noutros tipos de letra</target>
+        </trans-unit>
+        <trans-unit id="FontFamilyFilterInput.PlaceholderText" translate="yes" xml:space="preserve">
+          <source>Filter by family</source>
+          <target state="translated">Filtrar por família</target>
+        </trans-unit>
+        <trans-unit id="SettingsRememberFilter.Description" translate="yes" xml:space="preserve">
+          <source>If enabled, the app will remember the last selected collection or filter and restore it when the app is restarted. 
+
+Otherwise, "All Fonts" is selected by default on every launch.</source>
+          <target state="translated">Se esta opção estiver ativada, vai ser guardada a última coleção ou filtro selecionado e vai ser restaurada quando voltar a iniciar a aplicação. 
+
+Caso contrário, "Todos os tipos de letra" é selecionado por predefinição em todos os inícios.</target>
+        </trans-unit>
+        <trans-unit id="SettingsRememberFilter.Title" translate="yes" xml:space="preserve">
+          <source>Remember selected font list filter between sessions</source>
+          <target state="translated">Memorizar o filtro da lista dos tipos de letra selecionados entre sessões</target>
+        </trans-unit>
+        <trans-unit id="GlyphNameToggleHeader.Text" translate="yes" xml:space="preserve">
+          <source>File Name Template</source>
+          <target state="translated">Modelo de nome de ficheiro</target>
+        </trans-unit>
+        <trans-unit id="GlyphNameToggleLabel.Text" translate="yes" xml:space="preserve">
+          <source>Show template parts</source>
+          <target state="translated">Mostrar partes do modelo</target>
+        </trans-unit>
+        <trans-unit id="FileNameWriterCharDescDesc" translate="yes" xml:space="preserve">
+          <source>Glyph Unicode description, or Unicode string if none</source>
+          <target state="translated">Descrição Unicode do glifo ou, se nenhuma, cadeia Unicode</target>
+        </trans-unit>
+        <trans-unit id="FileNameWriterExtensionDesc" translate="yes" xml:space="preserve">
+          <source>File Extension</source>
+          <target state="translated">Extensão do ficheiro</target>
+        </trans-unit>
+        <trans-unit id="FileNameWriterFaceDesc" translate="yes" xml:space="preserve">
+          <source>Name of current font face</source>
+          <target state="translated">Nome da variação do tipo de letra atual</target>
+        </trans-unit>
+        <trans-unit id="FileNameWriterFamilyDesc" translate="yes" xml:space="preserve">
+          <source>Name of font family</source>
+          <target state="translated">Nome da família do tipo de letra</target>
+        </trans-unit>
+        <trans-unit id="FileNameWriterPixelSizeDesc" translate="yes" xml:space="preserve">
+          <source>Size in pixels</source>
+          <target state="translated">Tamanho em píxeis</target>
+        </trans-unit>
+        <trans-unit id="FileNameWriterStringFormat" translate="yes" xml:space="preserve">
+          <source>{0}, e.g. {1}</source>
+          <target state="translated">{0}, ex. {1}</target>
+        </trans-unit>
+        <trans-unit id="FileNameWriterUnicodeCPDesc" translate="yes" xml:space="preserve">
+          <source>Unicode index/codepoint value</source>
+          <target state="translated">Índice Unicode/valor ponto de código</target>
+        </trans-unit>
+        <trans-unit id="FileNameWriterUnicodeHexDesc" translate="yes" xml:space="preserve">
+          <source>Unicode hex value</source>
+          <target state="translated">Valor hexadecimal Unicode</target>
+        </trans-unit>
+        <trans-unit id="FileNameWriterXamlGlyphDesc" translate="yes" xml:space="preserve">
+          <source>XAML glyph code</source>
+          <target state="translated">Código de glifo XAML</target>
+        </trans-unit>
+        <trans-unit id="SettingsGlyphNaming.Description" translate="yes" xml:space="preserve">
+          <source>Choose how exported character files are named.</source>
+          <target state="translated">Escolha o nome dos ficheiros de caracteres exportados.</target>
+        </trans-unit>
+        <trans-unit id="SettingsGlyphNaming.Title" translate="yes" xml:space="preserve">
+          <source>Glyph Export Naming</source>
+          <target state="translated">Nomenclatura da exportação de glifos</target>
+        </trans-unit>
+        <trans-unit id="ExampleFormat" translate="yes" xml:space="preserve">
+          <source>e.g. {0}</source>
+          <target state="translated">ex. {0}</target>
+        </trans-unit>
+        <trans-unit id="FileNameWriterFontVerDesc" translate="yes" xml:space="preserve">
+          <source>Font version number, if applicable</source>
+          <target state="translated">Se aplicável, o numéro da versão do tipo de letra</target>
+        </trans-unit>
+        <trans-unit id="CanvasFontInformationCopyrightNotice" translate="yes" xml:space="preserve">
+          <source>Copyright Notice</source>
+          <target state="translated">Direitos de autor</target>
+        </trans-unit>
+        <trans-unit id="CanvasFontInformationDescription" translate="yes" xml:space="preserve">
+          <source>Description</source>
+          <target state="translated">Descrição</target>
+        </trans-unit>
+        <trans-unit id="CanvasFontInformationDesigner" translate="yes" xml:space="preserve">
+          <source>Designer</source>
+          <target state="translated">Autor</target>
+        </trans-unit>
+        <trans-unit id="CanvasFontInformationDesignerUrl" translate="yes" xml:space="preserve">
+          <source>Designer URL</source>
+          <target state="translated">URL do autor</target>
+        </trans-unit>
+        <trans-unit id="CanvasFontInformationFontVendorUrl" translate="yes" xml:space="preserve">
+          <source>Font Vendor URL</source>
+          <target state="translated">URL do fornecedor do tipo de letra</target>
+        </trans-unit>
+        <trans-unit id="CanvasFontInformationFullName" translate="yes" xml:space="preserve">
+          <source>Full Name</source>
+          <target state="translated">Nome completo</target>
+        </trans-unit>
+        <trans-unit id="CanvasFontInformationLicenseDescription" translate="yes" xml:space="preserve">
+          <source>License</source>
+          <target state="translated">Licença</target>
+        </trans-unit>
+        <trans-unit id="CanvasFontInformationLicenseInfoUrl" translate="yes" xml:space="preserve">
+          <source>License URL</source>
+          <target state="translated">URL da licença</target>
+        </trans-unit>
+        <trans-unit id="CanvasFontInformationManufacturer" translate="yes" xml:space="preserve">
+          <source>Manufacturer</source>
+          <target state="translated">Empresa</target>
+        </trans-unit>
+        <trans-unit id="CanvasFontInformationTrademark" translate="yes" xml:space="preserve">
+          <source>Trademark</source>
+          <target state="translated">Marca registada</target>
+        </trans-unit>
+        <trans-unit id="CanvasFontInformationVersionStrings" translate="yes" xml:space="preserve">
+          <source>Version Strings</source>
+          <target state="new">Version Strings</target>
+        </trans-unit>
+        <trans-unit id="RestoreLabel.Text" translate="yes" xml:space="preserve">
+          <source>Restore</source>
+          <target state="translated">Restaurar</target>
+          <note from="MultilingualBuild" annotates="source" priority="2">Opposite of Fullscreen</note>
+        </trans-unit>
+        <trans-unit id="CharFilter" translate="yes" xml:space="preserve">
+          <source>char:</source>
+          <target state="translated">car:</target>
+          <note from="MultilingualBuild" annotates="source" priority="2">Command used for character searches. Should be short.</note>
+        </trans-unit>
+        <trans-unit id="CreateSmartCollectionCheck.Content" translate="yes" xml:space="preserve">
+          <source>Create as Smart Collection</source>
+          <target state="translated">Criar como coleção inteligente</target>
+        </trans-unit>
+        <trans-unit id="CreateSmartCollectionHint.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" translate="yes" xml:space="preserve">
+          <source>View online documentation for Smart Collections</source>
+          <target state="translated">Ver online a documentação para coleções inteligentes</target>
+        </trans-unit>
+        <trans-unit id="DesignerFilter" translate="yes" xml:space="preserve">
+          <source>designer:</source>
+          <target state="translated">autor:</target>
+          <note from="MultilingualBuild" annotates="source" priority="2">Command used for designer searches. Should be short.</note>
+        </trans-unit>
+        <trans-unit id="FilePathFilter" translate="yes" xml:space="preserve">
+          <source>filepath:</source>
+          <target state="translated">caminho:</target>
+          <note from="MultilingualBuild" annotates="source" priority="2">Command used for file path searches. Should be short.</note>
+        </trans-unit>
+        <trans-unit id="FoundryFilter" translate="yes" xml:space="preserve">
+          <source>foundry:</source>
+          <target state="translated">empresa:</target>
+          <note from="MultilingualBuild" annotates="source" priority="2">Command used for foundry searches. Should be short.</note>
+        </trans-unit>
+        <trans-unit id="SmartCollectionDesignerFilter.Text" translate="yes" xml:space="preserve">
+          <source>Designer Filter</source>
+          <target state="translated">Filtro de autor</target>
+        </trans-unit>
+        <trans-unit id="SmartCollectionFilePathFilter.Text" translate="yes" xml:space="preserve">
+          <source>File Path Filter</source>
+          <target state="translated">Fitro de caminho do ficheiro</target>
+        </trans-unit>
+        <trans-unit id="SmartCollectionFoundryFilter.Text" translate="yes" xml:space="preserve">
+          <source>Foundry Filter</source>
+          <target state="translated">Fitro de empresa</target>
+        </trans-unit>
+        <trans-unit id="DigEditCollection.PrimaryButtonText" translate="yes" xml:space="preserve">
+          <source>Edit</source>
+          <target state="translated">Editar</target>
+        </trans-unit>
+        <trans-unit id="DigEditCollection.Title" translate="yes" xml:space="preserve">
+          <source>Edit Collection</source>
+          <target state="translated">Editar coleção</target>
+        </trans-unit>
+        <trans-unit id="EditCollectionButton.Label" translate="yes" xml:space="preserve">
+          <source>Edit</source>
+          <target state="translated">Editar</target>
+        </trans-unit>
+        <trans-unit id="EditCollectionButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" translate="yes" xml:space="preserve">
+          <source>Edit Collection</source>
+          <target state="translated">Editar coleção</target>
+        </trans-unit>
+        <trans-unit id="BtnHelpAndTips.Content" translate="yes" xml:space="preserve">
+          <source>Help &amp; Tips</source>
+          <target state="translated">Ajuda &amp; sugestões</target>
+        </trans-unit>
+        <trans-unit id="SmartCollectionEditHint.Text" translate="yes" xml:space="preserve">
+          <source>To modify smart collections use the edit button above.</source>
+          <target state="translated">Para modificar as coleções inteligentes, utilize o botão de editar acima.</target>
         </trans-unit>
       </group>
     </body>

--- a/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.ru-RU.xlf
+++ b/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.ru-RU.xlf
@@ -2226,6 +2226,10 @@ Otherwise, "All Fonts" is selected by default on every launch.</target>
           <source>To modify smart collections use the edit button above.</source>
           <target state="new">To modify smart collections use the edit button above.</target>
         </trans-unit>
+        <trans-unit id="DigOpenFolderContent.SelectFolderButtonContent" translate="yes" xml:space="preserve">
+          <source>Select Folder</source>
+          <target state="translated">Выбор папки</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.ta.xlf
+++ b/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.ta.xlf
@@ -2238,6 +2238,10 @@ Otherwise, "All Fonts" is selected by default on every launch.</target>
           <source>To modify smart collections use the edit button above.</source>
           <target state="new">To modify smart collections use the edit button above.</target>
         </trans-unit>
+        <trans-unit id="DigOpenFolderContent.SelectFolderButtonContent" translate="yes" xml:space="preserve">
+          <source>Select Folder</source>
+          <target state="translated">கோப்புறையைத் தேர்ந்தெடு</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.th-TH.xlf
+++ b/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.th-TH.xlf
@@ -2233,6 +2233,10 @@ Otherwise, "All Fonts" is selected by default on every launch.</target>
           <source>To modify smart collections use the edit button above.</source>
           <target state="new">To modify smart collections use the edit button above.</target>
         </trans-unit>
+        <trans-unit id="DigOpenFolderContent.SelectFolderButtonContent" translate="yes" xml:space="preserve">
+          <source>Select Folder</source>
+          <target state="translated">เลือกโฟลเดอร์r</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.zh-CN.xlf
+++ b/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.zh-CN.xlf
@@ -2223,6 +2223,10 @@ Otherwise, "All Fonts" is selected by default on every launch.</source>
           <source>To modify smart collections use the edit button above.</source>
           <target state="translated">要修改智能收藏集，请点击上方的编辑按钮。</target>
         </trans-unit>
+        <trans-unit id="DigOpenFolderContent.SelectFolderButtonContent" translate="yes" xml:space="preserve">
+          <source>Select Folder</source>
+          <target state="translated">选择文件夹</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.zh-TW.xlf
+++ b/CharacterMap/CharacterMap/MultilingualResources/CharacterMap.zh-TW.xlf
@@ -2229,6 +2229,10 @@ Otherwise, "All Fonts" is selected by default on every launch.</target>
           <source>To modify smart collections use the edit button above.</source>
           <target state="new">To modify smart collections use the edit button above.</target>
         </trans-unit>
+        <trans-unit id="DigOpenFolderContent.SelectFolderButtonContent" translate="yes" xml:space="preserve">
+          <source>Select Folder</source>
+          <target state="translated">選取資料夾</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/CharacterMap/CharacterMap/Strings/en-US/Resources.resw
+++ b/CharacterMap/CharacterMap/Strings/en-US/Resources.resw
@@ -1767,4 +1767,7 @@ Otherwise, "All Fonts" is selected by default on every launch.</value>
   <data name="SmartCollectionEditHint.Text" xml:space="preserve">
     <value>To modify smart collections use the edit button above.</value>
   </data>
+  <data name="DigOpenFolderContent.SelectFolderButtonContent" xml:space="preserve">
+    <value>Select Folder</value>
+  </data>
 </root>

--- a/CharacterMap/CharacterMap/Strings/pt-PT/Resources.resw
+++ b/CharacterMap/CharacterMap/Strings/pt-PT/Resources.resw
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <resheader name="resmimetype">
     <value>text/microsoft-resx</value>
@@ -13,58 +13,58 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AddToCollectionHint.Text" xml:space="preserve">
-    <value>Adicionar à Biblioteca</value>
+    <value>Adicionar à biblioteca</value>
   </data>
   <data name="AppName" xml:space="preserve">
-    <value>Mapa de Carateres</value>
+    <value>Mapa de caracteres UWP</value>
   </data>
   <data name="BlackFill.Text" xml:space="preserve">
-    <value>Preenchimento Preto</value>
+    <value>Preenchimento preto</value>
   </data>
   <data name="BtnCopy.Text" xml:space="preserve">
-    <value>Copiar como Texto</value>
+    <value>Copiar como texto</value>
   </data>
   <data name="BtnSelect.Content" xml:space="preserve">
     <value>Selecionar</value>
   </data>
   <data name="ColoredGlyphLabel.Text" xml:space="preserve">
-    <value>Colored Glyph</value>
+    <value>Glifo colorido</value>
   </data>
   <data name="ColorGlyphToggle.OffContent" xml:space="preserve">
-    <value>Monochrome glyphs</value>
+    <value>Glifo monocromático</value>
   </data>
   <data name="ColorGlyphToggle.OnContent" xml:space="preserve">
-    <value>Color glyphs</value>
+    <value>Glifos coloridos</value>
   </data>
   <data name="FontDisplayHeader.Text" xml:space="preserve">
-    <value>Opções de Visualização da Fonte</value>
+    <value>Opções de visualização do tipo de letra</value>
   </data>
   <data name="FontOptionsButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Opções de Renderização da Fonte</value>
+    <value>Opções de composição do tipo de letra</value>
   </data>
   <data name="FontPropertiesButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Propriedades do Rosto da Fonte</value>
+    <value>Propriedades do tipo de letra</value>
   </data>
   <data name="FontPropFace.Text" xml:space="preserve">
-    <value>Nome do Rosto</value>
+    <value>Nome da variante</value>
   </data>
   <data name="FontPropFamily.Text" xml:space="preserve">
-    <value>Nome da Familia</value>
+    <value>Nome da família</value>
   </data>
   <data name="FontPropMonospaced.Text" xml:space="preserve">
-    <value>É Monoespaçado</value>
+    <value>Monoespaçada</value>
   </data>
   <data name="FontPropStretch.Text" xml:space="preserve">
-    <value>Esticar</value>
+    <value>Largura</value>
   </data>
   <data name="FontPropStyle.Text" xml:space="preserve">
     <value>Estilo</value>
   </data>
   <data name="FontPropSymbol.Text" xml:space="preserve">
-    <value>É Fonte de Símbolo</value>
+    <value>Símbolos</value>
   </data>
   <data name="FontPropTitle.Text" xml:space="preserve">
-    <value>Propriedades do Rosto da Fonte</value>
+    <value>Propriedades do tipo de letra</value>
   </data>
   <data name="FontPropType.Text" xml:space="preserve">
     <value>Tipo</value>
@@ -73,117 +73,106 @@
     <value>Peso</value>
   </data>
   <data name="InvalidFontMessage" xml:space="preserve">
-    <value>Pedimos desculpa, não encontramos nenhum dado de fonte suportado neste ficheiro.</value>
+    <value>Pedimos desculpa, mas não conseguimos encontrar nenhum dado de tipo de letra suportado neste ficheiro.</value>
   </data>
   <data name="InvalidFontTitle" xml:space="preserve">
-    <value>Ficheiro não Suportado</value>
+    <value>Ficheiro não suportado</value>
   </data>
   <data name="OpenInNewWindow.Text" xml:space="preserve">
-    <value>Abrir numa Nova Janela</value>
+    <value>Abrir numa nova janela</value>
   </data>
   <data name="RemoveFontFlyout.Text" xml:space="preserve">
-    <value>Eliminar Fonte</value>
+    <value>Eliminar tipo de letra</value>
   </data>
   <data name="RestartButton.Content" xml:space="preserve">
-    <value>Reiniciar aplicação</value>
+    <value>Reiniciar a aplicação</value>
   </data>
   <data name="RestartHeader.Text" xml:space="preserve">
-    <value>Requer reinicialização da aplicação para fazer efeito.</value>
+    <value>Verá a sua alteração quando voltar a iniciar a aplicação.</value>
   </data>
   <data name="SearchBox.PlaceholderText" xml:space="preserve">
-    <value>Pesquise o nome do caráter ou o unicode hex</value>
+    <value>Procurar por nome ou hexadecimal unicode</value>
   </data>
   <data name="Settings_About.Text" xml:space="preserve">
     <value>Acerca desta aplicação</value>
   </data>
   <data name="Settings_AboutDescription.Text" xml:space="preserve">
-    <value>Esta aplicação foi projetada para substituir o Mapa de carateres do Windows Win32. É mais consciente do DPI em ecrãs de DPI alto.</value>
+    <value>Esta aplicação foi projetada para substituir o Mapa de carateres (Win32) do Windows. É mais consciente do PPP em ecrãs com PPP alto.</value>
   </data>
   <data name="TxtCopiedMessage.Text" xml:space="preserve">
     <value>Copiado</value>
   </data>
-  <data name="TxtFontIcon.Header" xml:space="preserve">
-    <value>Font Icon</value>
-    <comment>Xaml FontIcon. Does not need translation.</comment>
-  </data>
-  <data name="TxtSymbolIcon.Header" xml:space="preserve">
-    <value>Symbol Icon</value>
-    <comment>Xaml SymbolIcon. Does not need translation.</comment>
-  </data>
   <data name="TxtTitle.Text" xml:space="preserve">
-    <value>Mapa de Carateres</value>
+    <value>Mapa de caracteres</value>
   </data>
   <data name="TxtUnicode.Header" xml:space="preserve">
     <value>Unicode</value>
   </data>
   <data name="TxtXamlCode.Header" xml:space="preserve">
-    <value>Glyph Code</value>
+    <value>Código do glifo</value>
   </data>
   <data name="TypographyVariantsHeader.Text" xml:space="preserve">
-    <value>Glyph Variants</value>
+    <value>Alternativas estilísticas</value>
   </data>
   <data name="WhiteFill.Text" xml:space="preserve">
-    <value>Preenchimento Branco</value>
+    <value>Preenchimento branco</value>
   </data>
   <data name="ImportNotAFile" xml:space="preserve">
     <value>Não é um ficheiro</value>
   </data>
   <data name="ImportPendingDelete" xml:space="preserve">
-    <value>Fonte existente pendente para eliminação. Por favor, reinicie a aplicação.</value>
+    <value>Eliminação do tipo de letra pendente. Reinicie a aplicação.</value>
   </data>
   <data name="ImportUnavailableFile" xml:space="preserve">
     <value>Ficheiro não disponível</value>
   </data>
   <data name="ImportUnsupportedFileType" xml:space="preserve">
-    <value>Tipo de Ficheiro não Suportado</value>
+    <value>Ficheiro não suportado</value>
   </data>
   <data name="ImportUnsupportedFontType" xml:space="preserve">
-    <value>Tipo de Fonte não Suportado</value>
+    <value>Tipo de letra não suportado</value>
   </data>
   <data name="FontsClearedOnNextLaunchNotice" xml:space="preserve">
-    <value>Algumas fontes não podem ser completamente eliminadas agora. Essas fontes não vão aparecer na aplicação e serão completamente eliminadas na próxima vez que a aplicação for iniciado.</value>
+    <value>Alguns tipos de letra não foram completamente removidos. Esses tipos de letra não vão aparecer na aplicação e serão completamente removidos na próxima vez que voltar a iniciar a aplicação.</value>
   </data>
   <data name="SaveImageError" xml:space="preserve">
-    <value>Pedimos desculpa, aconteceu algo de errado enquanto estávamos a tentar guardar a imagem.</value>
+    <value>Pedimos desculpa, ocorreu um erro ao tentar guardar a imagem.</value>
   </data>
   <data name="LoadingFontListError" xml:space="preserve">
-    <value>Erro ao Carregar Lista de Fontes</value>
+    <value>Erro ao carregar a lista de tipos de letra</value>
   </data>
   <data name="NoticeLabel.Text" xml:space="preserve">
     <value>Atenção</value>
   </data>
   <data name="ImportFileCopyFail" xml:space="preserve">
-    <value>Aconteceu algo de errado. Por favor, tente novamente mais tarde.</value>
+    <value>Ocorreu um problema. Tente novamente.</value>
   </data>
   <data name="ImportFontHelpBlock.Text" xml:space="preserve">
-    <value>Arraste fontes para a aplicação para copiá-las na sua biblioteca.</value>
-  </data>
-  <data name="FontPropXaml.Text" xml:space="preserve">
-    <value>XAML FontFamily Source</value>
+    <value>Arraste ficheiros de tipo de letra e largue-os na aplicação para copiar tipos de letra à sua biblioteca.</value>
   </data>
   <data name="FilePickerConfirm" xml:space="preserve">
     <value>Importar</value>
   </data>
   <data name="ImportFontsButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Importar Fontes</value>
+    <value>Importar tipos de letra</value>
   </data>
   <data name="OpenFontButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Abrir Fonte</value>
+    <value>Abrir tipo de letra</value>
   </data>
   <data name="OpenFontPickerConfirm" xml:space="preserve">
     <value>Abrir</value>
   </data>
   <data name="CreateCollectionEntryBox.Header" xml:space="preserve">
-    <value>Nome da Coleção</value>
+    <value>Nome da coleção</value>
   </data>
   <data name="DigCreateCollection.PrimaryButtonText" xml:space="preserve">
     <value>Criar</value>
   </data>
   <data name="DigCreateCollection.Title" xml:space="preserve">
-    <value>Criar Coleção</value>
+    <value>Criar coleção</value>
   </data>
   <data name="DeleteCollectionButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Eliminar Coleção</value>
+    <value>Eliminar coleção</value>
   </data>
   <data name="DigCreateCollection.SecondaryButtonText" xml:space="preserve">
     <value>Cancelar</value>
@@ -195,160 +184,160 @@
     <value>Cancelar</value>
   </data>
   <data name="DigDeleteCollection.Title" xml:space="preserve">
-    <value>Tem a certeza de que quer eliminar esta coleção?</value>
+    <value>Tem a certeza de que pretende eliminar esta coleção?</value>
   </data>
   <data name="DigRenameCollection.PrimaryButtonText" xml:space="preserve">
     <value>Mudar o nome</value>
   </data>
   <data name="DigRenameCollection.Title" xml:space="preserve">
-    <value>Mudar o nome da Coleção</value>
+    <value>Mudar o nome da coleção</value>
   </data>
   <data name="OptionAllFonts.Text" xml:space="preserve">
-    <value>Todas as Fontes</value>
+    <value>Todos os tipos de letra</value>
   </data>
   <data name="OptionImportedFonts.Text" xml:space="preserve">
-    <value>Fontes Importadas</value>
+    <value>Tipos de letra importados</value>
   </data>
   <data name="OptionSymbolFonts.Text" xml:space="preserve">
-    <value>Fontes de Símbolos</value>
+    <value>Tipos de letra de símbolos</value>
   </data>
   <data name="RenameCollectionButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Mudar o nome da Coleção</value>
+    <value>Mudar o nome da coleção</value>
   </data>
   <data name="FontListDisplayHeader.Text" xml:space="preserve">
-    <value>Visualização da Lista de Fontes</value>
+    <value>Visualizador da lista de tipos de letra</value>
   </data>
   <data name="FontPropCount.Text" xml:space="preserve">
-    <value>Glyph Count</value>
+    <value>Número de glifos</value>
   </data>
   <data name="OptionMonospacedFonts.Text" xml:space="preserve">
-    <value>Fontes Monoespaçadas</value>
+    <value>Tipos de letra monoespaçada</value>
   </data>
   <data name="OptionSansSerifFonts.Text" xml:space="preserve">
-    <value>Fontes sem Serifa</value>
+    <value>Tipos de letra sem serifa</value>
   </data>
   <data name="OptionSerifFonts.Text" xml:space="preserve">
-    <value>Fontes Serifadas</value>
+    <value>Tipos de letra serifa</value>
   </data>
   <data name="NewCollectionItem.Text" xml:space="preserve">
-    <value>Nova Coleção</value>
+    <value>Nova coleção</value>
   </data>
   <data name="RemoveFromCollectionItem.Text" xml:space="preserve">
-    <value>Remover da Coleção</value>
+    <value>Remover da coleção</value>
   </data>
   <data name="AddToCollectionFlyout.Text" xml:space="preserve">
-    <value>Adicionar à Coleção</value>
+    <value>Adicionar à coleção</value>
   </data>
   <data name="InstantSearchToggle.OffContent" xml:space="preserve">
-    <value>Pesquisa instantânea desativada</value>
+    <value>Procura instantânea desligada</value>
   </data>
   <data name="InstantSearchToggle.OnContent" xml:space="preserve">
-    <value>Pesquisa instantânea ativada</value>
+    <value>Procura instantânea ligada</value>
   </data>
   <data name="SearchResultsSlider.Header" xml:space="preserve">
-    <value>Resultados máximos da pesquisa</value>
+    <value>Máximo de resultados da procura</value>
   </data>
   <data name="FontPropCharCount.Text" xml:space="preserve">
-    <value>Contagem de Carateres</value>
+    <value>Número de caracteres</value>
   </data>
   <data name="FontPropFilePath.Text" xml:space="preserve">
-    <value>Localização do Ficheiro</value>
+    <value>Localização do ficheiro</value>
   </data>
   <data name="DWriteSourceAppxPackage" xml:space="preserve">
     <value>Microsoft Store</value>
   </data>
   <data name="DWriteSourcePerMachine" xml:space="preserve">
-    <value>Todos os Utilizadores</value>
+    <value>Todos os utilizadores</value>
   </data>
   <data name="DWriteSourcePerUser" xml:space="preserve">
-    <value>Apenas o Utilizador Atual</value>
+    <value>Apenas o utilizador atual</value>
   </data>
   <data name="DWriteSourceRemoteFontProvider" xml:space="preserve">
-    <value>Fornecedor de Nuvem</value>
+    <value>Fornecedor de nuvem</value>
   </data>
   <data name="DWriteSourceUnknown" xml:space="preserve">
-    <value>Indefinido</value>
+    <value>Indeterminada</value>
   </data>
   <data name="FontPropInstallType.Text" xml:space="preserve">
-    <value>Instalar Tipo</value>
+    <value>Tipo de instalação</value>
   </data>
   <data name="OptionAppxFonts.Text" xml:space="preserve">
     <value>Da Microsoft Store</value>
   </data>
   <data name="OptionCloudFonts.Text" xml:space="preserve">
-    <value>Fontes baseadas em Nuvem</value>
+    <value>Tipos de letra da nuvem</value>
   </data>
   <data name="OptionColorFonts.Text" xml:space="preserve">
-    <value>Fontes de Cor</value>
+    <value>Tipos de letra de cor</value>
   </data>
   <data name="OptionDecorativeFonts.Text" xml:space="preserve">
-    <value>Fontes Decorativas</value>
+    <value>Tipos de letra decorativa</value>
   </data>
   <data name="OptionMoreFilters.Text" xml:space="preserve">
     <value>Mais</value>
   </data>
   <data name="OptionScriptFonts.Text" xml:space="preserve">
-    <value>Fontes de Script</value>
+    <value>Tipos de letra manuscrita</value>
   </data>
   <data name="StatusBarFontCount" xml:space="preserve">
-    <value>{0} Famílias de Fontes</value>
+    <value>{0} família(s) tipográfica(s)</value>
   </data>
   <data name="FontPropFileSize.Text" xml:space="preserve">
-    <value>Tamanho do Ficheiro</value>
+    <value>Tamanho do ficheiro</value>
   </data>
   <data name="InstallTypeImported" xml:space="preserve">
-    <value>Não Instalado (Importado)</value>
+    <value>Não instalada (importada)</value>
   </data>
   <data name="StatusBarCharacterCount" xml:space="preserve">
-    <value>{0} Carater(es)</value>
+    <value>{0} caracteres</value>
   </data>
   <data name="SearchDelaySelector.Header" xml:space="preserve">
-    <value>Atraso antes da pesquisa (ms)</value>
+    <value>Atraso antes da procura (ms)</value>
   </data>
   <data name="InstantSearchToggleHeader.Text" xml:space="preserve">
-    <value>Pesquisa Instantânea</value>
+    <value>Procura instantânea</value>
   </data>
   <data name="CharacterSavedMessage.Text" xml:space="preserve">
-    <value>Guardado para</value>
+    <value>Guardado em</value>
   </data>
   <data name="NotificationAddedToCollection" xml:space="preserve">
-    <value>{0} foi adicionado para a coleção "{1}"</value>
+    <value>{0} foi adicionada à coleção "{1}"</value>
   </data>
   <data name="BtnOpenFile.Content" xml:space="preserve">
-    <value>Abrir Ficheiro</value>
+    <value>Abrir ficheiro</value>
   </data>
   <data name="BtnOpenFolder.Content" xml:space="preserve">
-    <value>Mostrar numa Pasta</value>
+    <value>Mostrar numa pasta</value>
   </data>
   <data name="BtnHidePane.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Ocultar painel de fontes (Ctrl+L)</value>
+    <value>Ocultar painel de tipos de letra (Ctrl+L)</value>
   </data>
   <data name="NotificationImportFailed" xml:space="preserve">
-    <value>Importação Falhada</value>
+    <value>A importação falhou</value>
   </data>
   <data name="NotificationMultipleFontsAdded" xml:space="preserve">
-    <value>{0} ficheiros foram adicionados para a sua coleção</value>
+    <value>{0} ficheiros foram adicionados à tua coleção</value>
   </data>
   <data name="NotificationSingleFontAdded" xml:space="preserve">
-    <value>{0} foi adicionado para a sua coleção</value>
+    <value>{0} foi adicionado à tua coleção</value>
   </data>
   <data name="BtnShowPane.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Mostrar painel de fontes (Ctrl + L)</value>
+    <value>Mostrar painel de tipos de letra (Ctrl+L)</value>
   </data>
   <data name="BtnMoreIcon.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Mais</value>
   </data>
   <data name="FontListFilter.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Filtrar fontes</value>
+    <value>Filtrar tipos de letra</value>
   </data>
   <data name="ToggleFullScreenModeButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Alternar Ecrã Inteiro</value>
+    <value>Alternar ecrã inteiro</value>
   </data>
   <data name="DlgDeleteFont.Title" xml:space="preserve">
-    <value>Tem a certeza de que quer apagar esta fonte da sua biblioteca?</value>
+    <value>Tem a certeza de que pretende eliminar este tipo de letra da biblioteca?</value>
   </data>
   <data name="NotificationCollectionDeleted" xml:space="preserve">
-    <value>Coleção "{0}" eliminada</value>
+    <value>"{0}" coleção eliminada</value>
   </data>
   <data name="DlgException.PrimaryButtonText" xml:space="preserve">
     <value>OK</value>
@@ -357,13 +346,13 @@
     <value>Algo correu mal</value>
   </data>
   <data name="DlgExceptionCopyMessage.Text" xml:space="preserve">
-    <value>Copiar erro para a Área de Transferências e abrir GitHub</value>
+    <value>Copiar erro para a Área de Transferência e abrir o GitHub</value>
   </data>
   <data name="DlgExceptionExpander.Header" xml:space="preserve">
-    <value>Ver Detalhes Completos da Exceção</value>
+    <value>Ver detalhes completos da excepção</value>
   </data>
   <data name="DlgExceptionMessage.Text" xml:space="preserve">
-    <value>Para nos ajudar a depurar e corrigir isto para si, por favor, considere abrir um problema na nossa página GitHub e afixar os detalhes. Tentaremos corrigi-lo de imediato!</value>
+    <value>Para nos ajudar a depurar e a resolvê-lo, considere criar uma relatório de erro que nos pode enviar os detalhes na nossa página no GitHub. Tentaremos corrigir imediatamente!</value>
   </data>
   <data name="BtnClose.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Fechar</value>
@@ -372,10 +361,10 @@
     <value>Copiar</value>
   </data>
   <data name="BtnRateAndReview.Content" xml:space="preserve">
-    <value>Classifique &amp; Avalie</value>
+    <value>Classifique &amp; critique</value>
   </data>
   <data name="BtnXAMLGeometry.Content" xml:space="preserve">
-    <value>Clique para ver</value>
+    <value>Premir para ver</value>
   </data>
   <data name="RbThemeDark.Content" xml:space="preserve">
     <value>Escuro</value>
@@ -384,112 +373,108 @@
     <value>Claro</value>
   </data>
   <data name="RbThemeSystem.Content" xml:space="preserve">
-    <value>Predefinição do Windows</value>
+    <value>Utilizar definição do sistema</value>
   </data>
   <data name="RbUseActualFont.Content" xml:space="preserve">
-    <value>Utilizar fonte atual</value>
+    <value>Utilizar tipo de letra atual</value>
   </data>
   <data name="RbUseSystemFont.Content" xml:space="preserve">
-    <value>Utilizar fonte do sistema</value>
+    <value>Utilizar tipo de letra do sistema</value>
   </data>
   <data name="SettingsCharacterSearchDescription.Text" xml:space="preserve">
-    <value>Alternar para a pesquisa instantânea. Se desativado, você pode iniciar uma pesquisa utilizando a tecla Enter ou pressionando o ícone de pesquisar.</value>
+    <value>Mudar procura instantânea. Ao desligar, a procura inicia ao premir a tecla Enter ou o ícone de procura.</value>
   </data>
   <data name="SettingsCharacterSearchHeader.Text" xml:space="preserve">
-    <value>Pesquisa de Carateres</value>
+    <value>Procura de caracteres</value>
   </data>
   <data name="SettingsCharGridDescription.Text" xml:space="preserve">
-    <value>O tamanho dos carateres individuais dentro da grelha de carateres. Tamanhos menores podem afetar o desempenho.</value>
+    <value>O tamanho dos caracteres individuais dentro da grelha de caracteres. Tamanhos menores podem afetar o desempenho.</value>
   </data>
   <data name="SettingsCharGridHeader.Text" xml:space="preserve">
-    <value>Tamanho da Grelha de Carateres</value>
+    <value>Tamanho da grelha de caracteres</value>
   </data>
   <data name="SettingsCharPreviewHint.Text" xml:space="preserve">
-    <value>Pré-visualização da grelha de carateres</value>
+    <value>Pré-visualização da grelha de caracteres</value>
   </data>
   <data name="SettingsDevToolsDescription.Text" xml:space="preserve">
-    <value>Mostrar ferramentas para desenvolvedores XAML, como Ícone de Símbolo e Ícone de Fonte.</value>
+    <value>Mostrar as ferramentas para programdores XAML, como Symbol Icon e Font Icon.</value>
   </data>
   <data name="SettingsDevToolsGroupHeader.Text" xml:space="preserve">
-    <value>Funcionalidades de Desenvolvedor</value>
+    <value>Funcionalidades de programador</value>
   </data>
   <data name="SettingsDevToolsHeader.Text" xml:space="preserve">
-    <value>Mostrar funcionalidades de desenvolvedor</value>
+    <value>Mostrar funcionalidades de programador</value>
   </data>
   <data name="SettingsDevToolsLangDescription.Text" xml:space="preserve">
-    <value>Escolha a linguagem de desenvolvimento para o conteúdo das funcionalidades do desenvolvedor.</value>
+    <value>Escolha a linguagem de programação para o conteúdo das funcionalidades de programador.</value>
   </data>
   <data name="SettingsDevToolsLangHeader.Text" xml:space="preserve">
-    <value>Linguagem</value>
+    <value>Idioma</value>
   </data>
   <data name="SettingsExpensiveAnimationDescription.Text" xml:space="preserve">
-    <value>Anima a grelha de carateres ao redimensionar a janela.
-Ao ativar isto pode incorrer uma grande penalização de desempenho ao redimensionar a janela.</value>
+    <value>Anima a grelha de caracteres ao redimensionar a janela.
+Ativar esta definição pode incorrer uma grande penalização de desempenho ao redimensionar a janela.</value>
   </data>
   <data name="SettingsExpensiveAnimationHeader.Text" xml:space="preserve">
-    <value>Ativar animações de redimensionamento de janelas</value>
+    <value>Animações de redimensionamento da janela</value>
   </data>
   <data name="SettingsExportHeader.Text" xml:space="preserve">
     <value>Exportar</value>
   </data>
   <data name="SettingsFontListDescription.Text" xml:space="preserve">
-    <value>Escolha a fonte utilizada para exibir os nomes das fontes na lista de fontes.</value>
+    <value>Escolhe o tipo de letra utilizado para exibir os nomes dos tipos de letra na lista de tipos de letra.</value>
   </data>
   <data name="SettingsFontListPreviewHint.Text" xml:space="preserve">
-    <value>Pré-visualização da lista de fontes</value>
+    <value>Pré-visualização da lista de tipos de letra</value>
   </data>
   <data name="SettingsHeader.Text" xml:space="preserve">
     <value>Definições</value>
   </data>
   <data name="SettingsLanguageDescription.Text" xml:space="preserve">
     <value>Substituir o idioma na aplicação.
-Requer a reinicialização para ter efeito.</value>
+Verá a sua alteração quando voltar a iniciar a aplicação.</value>
   </data>
   <data name="SettingsLanguageHeader.Text" xml:space="preserve">
     <value>Substituição do idioma</value>
   </data>
   <data name="SettingsPNGExportDescription.Text" xml:space="preserve">
-    <value>O tamanho em pixels das imagens PNG exportadas.</value>
+    <value>O tamanho, em píxeis, das imagens PNG exportadas.</value>
   </data>
   <data name="SettingsPNGExportHeader.Text" xml:space="preserve">
-    <value>Tamanho da Exportação PNG</value>
+    <value>Tamanho da exportação PNG</value>
   </data>
   <data name="SettingsShadowsDescription.Text" xml:space="preserve">
-    <value>Permite sombras subtis de profundidade na IU. Apenas perceptível quando se utiliza o tema Claro.
-Ativar isto pode ter um pequeno impacto no desempenho de dispositivos mais fracos.
-Requer a reinicialização para ter efeito.</value>
+    <value>Ativa sombras de profundidade subtis na IU. Apenas percetível ao utilizar o tema claro.
+Ativar esta opção pode ter um pequeno impacto no desempenho em dispositivos mais fracos.
+Verá a sua alteração quando voltar a iniciar a aplicação.</value>
   </data>
   <data name="SettingsShadowsHeader.Text" xml:space="preserve">
-    <value>Ativar sombras</value>
+    <value>Sombras</value>
   </data>
   <data name="SettingsSimpleAnimationDescription.Text" xml:space="preserve">
-    <value>Controla a animação para carregar a lista de fontes, mudar as fontes e mudar os carateres.
-Ativar isto tem um impacto de desempenho negligenciável.</value>
+    <value>Controla a maioria das animações dentro da aplicação. Desligar esta opção desativa a maioria das animações.
+Ativar esta opção tem um impacto insignificante no desempenho.</value>
   </data>
   <data name="SettingsSimpleAnimationHeader.Text" xml:space="preserve">
-    <value>Ativar animações simples</value>
+    <value>Animações</value>
   </data>
   <data name="SettingsThemeHeader.Text" xml:space="preserve">
     <value>Tema</value>
   </data>
   <data name="SettingsUIHeader.Text" xml:space="preserve">
-    <value>Interface de Utilizador</value>
-  </data>
-  <data name="TxtPathGeometry.Text" xml:space="preserve">
-    <value>Path Geometry</value>
-    <comment>Xaml PathGeometry. Does not need translation.</comment>
+    <value>Esquema</value>
   </data>
   <data name="UseSystemLanguage" xml:space="preserve">
-    <value>Utilizar definição de idioma do sistema</value>
+    <value>Utilizar o idioma de apresentação do sistema</value>
   </data>
   <data name="SettingsNeedRestart.Text" xml:space="preserve">
-    <value>A alteração será aplicada após reinício</value>
+    <value>Verá a sua alteração quando voltar a iniciar a aplicação</value>
   </data>
   <data name="BtnContributors.Content" xml:space="preserve">
     <value>Contribuidores</value>
   </data>
   <data name="TxtLoadingFonts.Text" xml:space="preserve">
-    <value>A Carregar Fontes</value>
+    <value>A carregar tipos de letra</value>
   </data>
   <data name="AppBtnClear.Label" xml:space="preserve">
     <value>Limpar</value>
@@ -498,7 +483,7 @@ Ativar isto tem um impacto de desempenho negligenciável.</value>
     <value>Repor</value>
   </data>
   <data name="AppBtnSelectAll.Label" xml:space="preserve">
-    <value>Selecionar Tudo</value>
+    <value>Selecionar tudo</value>
   </data>
   <data name="BtnApply.Content" xml:space="preserve">
     <value>Aplicar</value>
@@ -513,104 +498,104 @@ Ativar isto tem um impacto de desempenho negligenciável.</value>
     <value>Imprimir</value>
   </data>
   <data name="CbCharacterLabel.Header" xml:space="preserve">
-    <value>Etiqueta do Carater</value>
+    <value>Etiqueta do carácter</value>
   </data>
   <data name="CbiPageOrientationLandscape.Content" xml:space="preserve">
-    <value>Paisagem</value>
+    <value>Vertical</value>
   </data>
   <data name="CbiPageOrientationPortrait.Content" xml:space="preserve">
-    <value>Retrato</value>
+    <value>Horizontal</value>
   </data>
   <data name="CbListStyle.Header" xml:space="preserve">
-    <value>Estilo da Lista</value>
+    <value>Estilo da lista</value>
   </data>
   <data name="CbShowMargins.Content" xml:space="preserve">
-    <value>Mostrar Margens</value>
+    <value>Mostrar margens</value>
   </data>
   <data name="ChkBxHideWhitespace.Content" xml:space="preserve">
-    <value>Ocultar espaços em branco e controlar carateres</value>
+    <value>Ocultar espaços em branco e caracteres de controlo</value>
   </data>
   <data name="ChkBxShowBorders.Content" xml:space="preserve">
     <value>Mostrar bordas</value>
   </data>
   <data name="GlyphAnnotation_None" xml:space="preserve">
-    <value>Nenhum</value>
+    <value>Nenhuma</value>
   </data>
   <data name="GlyphAnnotation_UnicodeHex" xml:space="preserve">
-    <value>Unicode Hex</value>
+    <value>Hexademical Unicode</value>
   </data>
   <data name="GlyphAnnotation_UnicodeIndex" xml:space="preserve">
-    <value>Unicode Index</value>
+    <value>Índice Unicode</value>
   </data>
   <data name="PrintCharacterFilterContent.Text" xml:space="preserve">
-    <value>Escolha os grupos de carateres a exibir</value>
+    <value>Escolhe o grupo de caracteres a apresentar</value>
   </data>
   <data name="PrintDataHeader.Text" xml:space="preserve">
-    <value>Dado</value>
+    <value>Dados</value>
   </data>
   <data name="PrintViewCharSize.Text" xml:space="preserve">
-    <value>Tamanho do Carater</value>
+    <value>Tamanho do carácter</value>
   </data>
   <data name="PrintViewHorizontalMarginHeader.Text" xml:space="preserve">
-    <value>Margem Horizontal</value>
+    <value>Margem horizontal</value>
   </data>
   <data name="PrintViewLayoutHeader.Text" xml:space="preserve">
-    <value>Layout</value>
+    <value>Esquema</value>
   </data>
   <data name="PrintViewOfLabel.Text" xml:space="preserve">
     <value>de</value>
   </data>
   <data name="PrintViewPageOrientation.Header" xml:space="preserve">
-    <value>Orientação da Página</value>
+    <value>Orientação da página</value>
   </data>
   <data name="PrintViewPageRange.Text" xml:space="preserve">
-    <value>Intervalo da Página</value>
+    <value>Intervalo de páginas</value>
   </data>
   <data name="PrintViewPageRangeDesc.Text" xml:space="preserve">
-    <value>Podem ser imprimido até 50 páginas de cada vez. Selecione aqui o intervalo de páginas a imprimir.</value>
+    <value>Podem ser impressas até 50 páginas de uma vez. Selecione aqui o intervalo de páginas a imprimir.</value>
   </data>
   <data name="PrintViewPageRangeSelector.Header" xml:space="preserve">
     <value>Páginas para imprimir:</value>
   </data>
   <data name="PrintViewPageSelector.Header" xml:space="preserve">
-    <value>Iniciar da página:</value>
+    <value>Iniciar na página:</value>
   </data>
   <data name="PrintViewPageSetupHeader.Text" xml:space="preserve">
-    <value>Definição da Página</value>
+    <value>Configuração da página</value>
   </data>
   <data name="PrintViewPreviewingLabel.Text" xml:space="preserve">
-    <value>Pré-visualizando a página</value>
+    <value>Pré-visualização da página</value>
   </data>
   <data name="PrintViewPreviewOutOfBoundsLabel.Text" xml:space="preserve">
-    <value>Esta página está fora do intervalo de páginas atual e não será imprimido.
-Pode alterar o intervalo de páginas na secção Definição da Página.</value>
+    <value>Esta página está fora do intervalo de páginas atual e não será impressa.
+Pode alterar o intervalo de páginas na secção Configuração da página.</value>
   </data>
   <data name="PrintViewPrintingLabel" xml:space="preserve">
-    <value>Imprimindo páginas {0} - {1}</value>
+    <value>A imprimir página {0} - {1}</value>
   </data>
   <data name="PrintViewTitle.Text" xml:space="preserve">
-    <value>Definição de Impressão</value>
+    <value>Configuração de impressão</value>
   </data>
   <data name="PrintViewVerticalMarginHeader.Text" xml:space="preserve">
-    <value>Margem Vertical</value>
+    <value>Margem vertical</value>
   </data>
   <data name="SettingsCharLabel.Text" xml:space="preserve">
-    <value>Etiqueta do Carater</value>
+    <value>Etiqueta do carácter</value>
   </data>
   <data name="SettingsCharLabelDesc.Text" xml:space="preserve">
-    <value>Escolha a etiqueta a mostrar sob cada carater. Pode ter um efeito menor no desempenho de deslocamento.</value>
+    <value>Escolhe a etiqueta a mostrar debaixo de cada carácter. Pode ter um efeito menor no desempenho do deslocamento.</value>
   </data>
   <data name="SettingsManageSystemFonts.Content" xml:space="preserve">
-    <value>Gerir fontes instaladas</value>
+    <value>Gerir tipos de letra instalados</value>
   </data>
   <data name="SettingsSystemFontHeader.Text" xml:space="preserve">
-    <value>Fontes Instaladas</value>
+    <value>Tipos de letra instalados</value>
   </data>
   <data name="SettingsWindowsThemeSettings.Content" xml:space="preserve">
     <value>Definições do tema do Windows</value>
   </data>
   <data name="UnicodeFiltersTitle.Text" xml:space="preserve">
-    <value>FILTROS DA CATEGORIA UNICODE</value>
+    <value>FILTROS DE CATEGORIA UNICODE</value>
   </data>
   <data name="PrintLayout_Grid" xml:space="preserve">
     <value>Grelha</value>
@@ -619,27 +604,27 @@ Pode alterar o intervalo de páginas na secção Definição da Página.</value>
     <value>Lista</value>
   </data>
   <data name="PrintLayout_TwoColumn" xml:space="preserve">
-    <value>Duas Colunas</value>
+    <value>Duas colunas</value>
   </data>
   <data name="SettingsTransparencyDescription.Text" xml:space="preserve">
-    <value>Ativa os efeitos de transparência na IU. Se a transparência for desativada nas definições do Windows, isto não terá qualquer efeito.
-Pode ter um efeito menor no desempenho em dispositivos mais antigos ou mais fracos.</value>
+    <value>Ativa efeitos de transparência na IU. Se os efeitos de transparência estiverem desligados nas definições do Windows, esta opção não terá qualquer efeito.
+Pode ter um pequeno efeito no desempenho em dispositivos mais antigos ou fracos.</value>
   </data>
   <data name="SettingsTransparencyHeader.Text" xml:space="preserve">
-    <value>Ativar transparência</value>
+    <value>Transparência</value>
   </data>
   <data name="StartupFailedButton.Content" xml:space="preserve">
-    <value>Mostrar Detalhes</value>
+    <value>Mostrar detalhes</value>
   </data>
   <data name="StartupFailedHeader.Text" xml:space="preserve">
-    <value>Uh Oh</value>
+    <value>Ups</value>
   </data>
   <data name="StartupFailedMessage.Text" xml:space="preserve">
-    <value>Ocorreu algo de errado e não pudemos iniciar a aplicação neste momento.
-Por favor, considere a possibilidade de colocar detalhes sobre este erro no GitHub para que o possamos ajudar a corrigi-lo.</value>
+    <value>Ocorreu um erro e não foi possível iniciar a aplicação neste momento.
+Considere colocar detalhes sobre este erro no GitHub para lhe podermos ajudar a corrigi-lo.</value>
   </data>
   <data name="CharacterKeystrokeLabel" xml:space="preserve">
-    <value>Pressionamento de teclas: Alt + {0: 0000}</value>
+    <value>Combinação de tecla: Alt + {0:0000}</value>
   </data>
   <data name="ExportSVGLabel.Text" xml:space="preserve">
     <value>Guardar como Imagem SVG</value>
@@ -648,13 +633,13 @@ Por favor, considere a possibilidade de colocar detalhes sobre este erro no GitH
     <value>Guardar como Imagem PNG</value>
   </data>
   <data name="ExportSVGGlyphLabel.Text" xml:space="preserve">
-    <value>Glyph SVG</value>
+    <value>Glifo SVG</value>
   </data>
   <data name="BtnCopyGlyph.Label" xml:space="preserve">
     <value>Copiar</value>
   </data>
   <data name="BtnCopyGlyph.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Copiar para a Área de Transferências</value>
+    <value>Copiar para a área de transferência</value>
   </data>
   <data name="BtnSaveGlyph.Label" xml:space="preserve">
     <value>Guardar como</value>
@@ -663,50 +648,46 @@ Por favor, considere a possibilidade de colocar detalhes sobre este erro no GitH
     <value>Guardar como</value>
   </data>
   <data name="BtnFit.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Carater Adaptado</value>
+    <value>Ajustar carácter</value>
   </data>
   <data name="NotificationFontRemovedBody.Text" xml:space="preserve">
     <value>foi removido de</value>
   </data>
   <data name="NotificationFontAddedBody.Text" xml:space="preserve">
-    <value>foi adicionado para</value>
+    <value>foi adicionado a</value>
   </data>
   <data name="ExportFontFile.Text" xml:space="preserve">
-    <value>Ficheiro da Fonte</value>
+    <value>Ficheiro de tipo de letra</value>
   </data>
   <data name="ExportFontFileLabel.Text" xml:space="preserve">
-    <value>Guardar Ficheiro da Fonte como</value>
+    <value>Guardar tipo de letra como</value>
   </data>
   <data name="FontExportedMessage" xml:space="preserve">
     <value>{0} exportado</value>
   </data>
   <data name="CollectionExportButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Exportar Fontes</value>
+    <value>Exportar tipos de letra</value>
   </data>
   <data name="CollectionExportFolder.Text" xml:space="preserve">
-    <value>para a Pasta</value>
+    <value>Para a pasta</value>
   </data>
   <data name="CollectionExportHeader.Text" xml:space="preserve">
-    <value>Exportar Fontes</value>
+    <value>Exportar tipos de letra</value>
   </data>
   <data name="CollectionExportZip.Text" xml:space="preserve">
-    <value>como Ficheiro Zip</value>
+    <value>Como pasta comprimida (zipada)</value>
   </data>
   <data name="SystemFontsExpiredMessage.Text" xml:space="preserve">
-    <value>As listas das fontes estão desatualizadas. Clique para reiniciar a aplicação.</value>
+    <value>As listas dos tipos de letra estão desatualizadas. Premir para voltar a iniciar a aplicação.</value>
   </data>
   <data name="BtnToggleDev.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Alternar Utilitários de Desenvolvimento</value>
-  </data>
-  <data name="TxtPathIcon.Text" xml:space="preserve">
-    <value>Path Icon</value>
-    <comment>Xaml PathIcon. Does not need translation.</comment>
+    <value>Ativar/desativar ferramentas de programador</value>
   </data>
   <data name="OptionAllEmoji.Text" xml:space="preserve">
-    <value>Todas as Categorias</value>
+    <value>Todas as categorias</value>
   </data>
   <data name="OptionAllEmojiTitle.Text" xml:space="preserve">
-    <value>Todos os Emojis</value>
+    <value>Todos os emojis</value>
   </data>
   <data name="OptionEmojiDingbats.Text" xml:space="preserve">
     <value>Dingbats</value>
@@ -715,16 +696,16 @@ Por favor, considere a possibilidade de colocar detalhes sobre este erro no GitH
     <value>Emoticons</value>
   </data>
   <data name="OptionEmojiSymbols.Text" xml:space="preserve">
-    <value>Símbolos &amp; Pictogramas</value>
+    <value>Símbolos &amp; pictogramas</value>
   </data>
   <data name="OptionScriptArabic.Text" xml:space="preserve">
-    <value>Arábico</value>
+    <value>Árabe</value>
   </data>
   <data name="OptionScriptBasicLatin.Text" xml:space="preserve">
-    <value>Latin</value>
+    <value>Latim</value>
   </data>
   <data name="OptionScriptCJKUnifiedIdeographs.Text" xml:space="preserve">
-    <value>CJK</value>
+    <value>CJK (Chinês/Japonês/Coreano)</value>
   </data>
   <data name="OptionScriptCyrillic.Text" xml:space="preserve">
     <value>Cirílico</value>
@@ -739,13 +720,13 @@ Por favor, considere a possibilidade de colocar detalhes sobre este erro no GitH
     <value>Tailandês</value>
   </data>
   <data name="CultureSpecificPangram.Text" xml:space="preserve">
-    <value>Já fiz vinho com toque de kiwi para belga sexy. 1234567890</value>
+    <value>Bancos fúteis pagavam-lhe queijo, whisky e xadrez. 1234567890</value>
   </data>
   <data name="LblSwitchToCharMap.Text" xml:space="preserve">
-    <value>Mudar para a Visualização Mapa de Carateres (Ctrl+T)</value>
+    <value>Mudar para a visualização Mapa de Carácter (Ctrl+T)</value>
   </data>
   <data name="LblSwitchToTypeRamp.Text" xml:space="preserve">
-    <value>Mudar para a Visualização Tipo Rampa (Ctrl+T)</value>
+    <value>Mudar para a visualização Rampa (Ctrl+T)</value>
   </data>
   <data name="TypeRampInputBox.PlaceholderText" xml:space="preserve">
     <value>Introduza ou escolha texto a partir do menu suspenso</value>
@@ -754,48 +735,48 @@ Por favor, considere a possibilidade de colocar detalhes sobre este erro no GitH
     <value>Exportado para {0}</value>
   </data>
   <data name="ImportDragDropDescriptionLabel.Text" xml:space="preserve">
-    <value>Arraste os ficheiros do Explorador de Ficheiros ou do seu ambiente de trabalho e largue-os aqui para os importar.</value>
+    <value>Arraste ficheiros do Explorador de Ficheiros ou do seu ambiente de trabalho e largue-os aqui para importar.</value>
   </data>
   <data name="ImportDragDropLabel.Text" xml:space="preserve">
     <value>Arraste e largue para importar</value>
   </data>
   <data name="SettingsAboutLabel.Text" xml:space="preserve">
-    <value>Acerca de</value>
+    <value>Acerca</value>
   </data>
   <data name="SettingsAdvancedUILabel.Text" xml:space="preserve">
-    <value>Interface de Utilizador Avançado</value>
+    <value>Aspeto &amp; Feel</value>
   </data>
   <data name="SettingsExportImportedLabel.Text" xml:space="preserve">
-    <value>Exportar todas as fontes importadas</value>
+    <value>Exportar todos os tipos de letra importados</value>
   </data>
   <data name="SettingsFontExportOptimizedLabel.Text" xml:space="preserve">
-    <value>Otimizado</value>
+    <value>Optimizado</value>
   </data>
   <data name="SettingsFontExportSystemLabel.Text" xml:space="preserve">
     <value>Sistema</value>
   </data>
   <data name="SettingsFontImportDescription.Text" xml:space="preserve">
-    <value>Pode importar fontes para a aplicação para as visualizar sem as instalar no Windows. 
+    <value>Pode importar tipos de letra para os visualizar sem os instalar no Windows. 
 
-Os ficheiros de fontes importadas são copiados para o armazenamento privado da aplicação, pelo que continuará a aparecer se apagar o ficheiro original no seu computador.</value>
+Os ficheiros de tipo de letra importados são copiados para o armazenamento privado da aplicação, pelo que continuam a ser exibidos mesmo que elimine o ficheiro original no seu dispositivo.</value>
   </data>
   <data name="SettingsFontManagementLabel.Text" xml:space="preserve">
-    <value>Gestão de Fontes</value>
+    <value>Gestão de tipos de letra</value>
   </data>
   <data name="SettingsFontNameExportDescription.Text" xml:space="preserve">
-    <value>Escolha como nomear os ficheiros da fonte quando os exportar.
+    <value>Escolhe como nomear os ficheiros de tipo de letra na exportação.
 
-O sistema devolverá o nome do ficheiro da fonte que o Windows usa em maiúsculas.
-Otimizado irá criar um nome inteligente baseado na Família da Fonte e no Nome da Fonte.</value>
+Sistema devolverá o nome do tipo de letra que o Windows utiliza em maiúsculas.
+Optimizado cria um nome inteligente baseado no nome da família e no nome do tipo de letra.</value>
   </data>
   <data name="SettingsFontNameExportLabel.Text" xml:space="preserve">
-    <value>Nomeação da Exportação de Ficheiros das Fontes</value>
+    <value>Nomenclatura da exportação dos ficheiros de tipo de letra</value>
   </data>
   <data name="SettingsImportedFontsLabel.Text" xml:space="preserve">
-    <value>Fontes Importadas</value>
+    <value>Tipos de letra importados</value>
   </data>
   <data name="SettingsLicensesDescriptionLabel.Text" xml:space="preserve">
-    <value>Esta aplicação faz uso das seguintes bibliotecas de código-fonte aberto</value>
+    <value>Esta aplicação utiliza as seguintes bibliotecas de código aberto</value>
   </data>
   <data name="SettingsLicensesLabel.Text" xml:space="preserve">
     <value>Licenças</value>
@@ -804,43 +785,43 @@ Otimizado irá criar um nome inteligente baseado na Família da Fonte e no Nome 
     <value>Repor</value>
   </data>
   <data name="OptionVariableFonts.Text" xml:space="preserve">
-    <value>Fontes Variáveis</value>
+    <value>Tipos de letra variável</value>
   </data>
   <data name="VariableFeaturesMessage.Text" xml:space="preserve">
-    <value>Esta fonte tem caraterísticas variáveis. Para as explorar, mude para a vista Tipo Rampa utilizando o botão de troca acima.</value>
+    <value>Este tipo de letra tem características variáveis. Para explorar as características, mude para a visualização Rampa utilizando o botão ativar/desativar acima.</value>
   </data>
   <data name="SettingsEnablePaneDescription.Text" xml:space="preserve">
-    <value>Mostra ou oculta o painel de pré-visualização no lado direito do ecrã. Se desativado, muitas funções ainda podem ser acedidas clicando com o botão direito do rato ou segurando o toque num carater dentro da grelha de carateres.</value>
+    <value>Mostra ou oculta o painel de pré-visualização no lado direito do ecrã. Se oculto, ainda pode aceder a algumas das funções ao clicar com o botão direito do rato ou tocar sem soltar no carácter dentro da grelha.</value>
   </data>
   <data name="SettingsEnablePaneHeader.Text" xml:space="preserve">
-    <value>Pré-visualização do Painel de Visualização</value>
+    <value>Visualização do painel de pré-visualização</value>
   </data>
   <data name="CopyFontIconCode.Text" xml:space="preserve">
-    <value>Copiar FontIcon Code</value>
+    <value>Copiar código FontIcon</value>
   </data>
   <data name="CopyGlyphCode.Text" xml:space="preserve">
-    <value>Copiar Glyph Code</value>
+    <value>Copiar código do glifo</value>
   </data>
   <data name="CopyPathIconCode.Text" xml:space="preserve">
-    <value>Copiar PathIcon Code</value>
+    <value>Copiar código PathIcon</value>
   </data>
   <data name="SearchBoxShorter" xml:space="preserve">
-    <value>Pesquisar...</value>
+    <value>Procurar...</value>
   </data>
   <data name="CopyUnicodeValue.Text" xml:space="preserve">
-    <value>Copiar Valor Unicode</value>
+    <value>Copiar valor Unicode</value>
   </data>
   <data name="DecreaseSizeButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Diminuir o Tamanho do Carater (Ctrl+-)</value>
+    <value>Diminuir tamanho do carácter (Ctrl+-)</value>
   </data>
   <data name="IncreaseSizeButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Aumentar o Tamanho do Carater (Ctrl++)</value>
+    <value>Aumentar tamanho do carácter (Ctrl++)</value>
   </data>
   <data name="SwitchViewButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Trocar Visualização (Ctrl+T)</value>
+    <value>Mudar vista (Ctrl+T)</value>
   </data>
   <data name="TogglePaneButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Trocar Painel de Pré-visualização (Ctrl+R)</value>
+    <value>Ativar/desativar painel de pré-visualização (Ctrl+R)</value>
   </data>
   <data name="NotificationCopied" xml:space="preserve">
     <value>Copiado</value>
@@ -849,44 +830,44 @@ Otimizado irá criar um nome inteligente baseado na Família da Fonte e no Nome 
     <value>Adicionar</value>
   </data>
   <data name="AddSelectionItem.Text" xml:space="preserve">
-    <value>Adicionar à Seleção</value>
+    <value>Adicionar à seleção</value>
   </data>
   <data name="CopySequencePlaceholder.Text" xml:space="preserve">
-    <value>clique duas vezes em um carater ou utilize o botão Adicionar</value>
+    <value>fazer duplo clique num carácter ou utilize o botão Adicionar</value>
   </data>
   <data name="ToggleCopyPaneButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Trocar Painel de Cópia (Ctrl+B)</value>
+    <value>Ativar/desativar painel de cópia (Ctrl+B)</value>
   </data>
   <data name="CompactOverlayButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Manter no topo</value>
   </data>
   <data name="TypographyVariationsSelectorRun.Text" xml:space="preserve">
-    <value>Variações Tipográficas</value>
+    <value>variações de tipografia</value>
   </data>
   <data name="ToggleDevDefaultLabel" xml:space="preserve">
     <value>Ferramentas</value>
   </data>
   <data name="BtnFit.Label" xml:space="preserve">
-    <value>Adaptar</value>
+    <value>Ajustar</value>
   </data>
   <data name="TxtCopiedVariantMessage.Text" xml:space="preserve">
-    <value>As variações do glyph não podem ser copiadas.
-Variante predefinida copiada.</value>
+    <value>Não é possível copiar variações de glifo.
+Foi copiada a variante predefinida.</value>
   </data>
   <data name="CollectionFontHelpBlock.Text" xml:space="preserve">
-    <value>Ainda não existem fontes nesta coleção.</value>
+    <value>Ainda não existem tipos de letra nesta coleção.</value>
   </data>
   <data name="SearchFontHelpBlock.Text" xml:space="preserve">
-    <value>Não foram encontrados resultados para esta pesquisa. Tente outra coisa.</value>
+    <value>Não conseguimos encontrar o que procurava. Tente algo diferente.</value>
   </data>
   <data name="FontListSearchBox.PlaceholderText" xml:space="preserve">
-    <value>Encontrar uma família de fontes</value>
+    <value>Localizar uma família tipográfica</value>
   </data>
   <data name="BtnToggleDev.Label" xml:space="preserve">
     <value>Ferramentas</value>
   </data>
   <data name="DevPopupHeader.Text" xml:space="preserve">
-    <value>Mostrar Ferramentas de Desenvolvedor</value>
+    <value>Mostrar ferramentas de programação</value>
   </data>
   <data name="ContextMenuDevCopyCommand" xml:space="preserve">
     <value>Copiar {0}</value>
@@ -896,73 +877,729 @@ Variante predefinida copiada.</value>
     <value>Nenhum</value>
   </data>
   <data name="SettingsChangelogLabel.Text" xml:space="preserve">
-    <value>Registo de Alterações</value>
-  </data>
-  <data name="TxtFontImageSource.Text" xml:space="preserve">
-    <value>Font Image Source</value>
-    <comment>Xamarin FontImageSource. Does not need translation.</comment>
+    <value>Notas de versão</value>
   </data>
   <data name="ImportFailedWoff" xml:space="preserve">
-    <value>A fonte WOFF não pôde ser convertida para uma fonte OTF válida.</value>
+    <value>Não foi possível converter o tipo de letra WOFF para um tipo de letra OTF válido.</value>
   </data>
   <data name="ImportWOFF2NotSupported" xml:space="preserve">
-    <value>Os ficheiros WOFF2 não são suportados</value>
+    <value>Ficheiros WOFF2 não são suportados</value>
   </data>
   <data name="CharacterFilterButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Filtrar Carateres</value>
+    <value>Filtrar caracteres</value>
   </data>
   <data name="CompareFontsTitle.Text" xml:space="preserve">
-    <value>Comparar Fontes</value>
+    <value>Comparar tipos de letra</value>
   </data>
   <data name="LayoutGridToggle.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Layout da Grelha</value>
+    <value>Esquema grelha</value>
   </data>
   <data name="LayoutListToggle.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Layout da Lista</value>
+    <value>Esquema lista</value>
   </data>
   <data name="QuickCompareTitle.Text" xml:space="preserve">
-    <value>Comparação Rápida</value>
+    <value>Comparação rápida</value>
   </data>
   <data name="AddToQuickCompare.Text" xml:space="preserve">
-    <value>Adicionar para Comparação Rápida</value>
+    <value>Adicionar à comparação rápida</value>
   </data>
   <data name="CompareFontsButton.Text" xml:space="preserve">
-    <value>Comparar todas as Fontes</value>
+    <value>Comparar todos os tipos de letra</value>
   </data>
   <data name="BtnGithubCommits.Content" xml:space="preserve">
-    <value>Veja os últimos commits no Github</value>
+    <value>Ver as revisões mais recentes no Github</value>
   </data>
   <data name="ExportGlyphsHeader.Text" xml:space="preserve">
-    <value>Exportar Carateres</value>
+    <value>Exportar caracteres</value>
   </data>
   <data name="ExportGlyphsSummary.Text" xml:space="preserve">
-    <value>Pronto para exportar {0} carateres como {1}</value>
+    <value>Pronto para exportar {0} caracteres como {1}</value>
   </data>
   <data name="ExportCharactersLabel.Text" xml:space="preserve">
-    <value>Exportar Carateres</value>
+    <value>Exportar caracteres</value>
   </data>
   <data name="ExportGlyphsResultMessage.Text" xml:space="preserve">
-    <value>{0} carater(es) exportado(s)</value>
+    <value>{0} caracteres exportados</value>
   </data>
   <data name="ExportGlyphsProgressMessage.Text" xml:space="preserve">
-    <value>Exportar carater {0} de {1}</value>
+    <value>A exportar carácter {0} de {1}</value>
   </data>
   <data name="ExportAllowColor.Content" xml:space="preserve">
-    <value>Permitir que a fonte utilize as suas próprias cores, se definidas</value>
+    <value>Permitir, se presentes, que o tipo de letra utilize as suas próprias cores</value>
   </data>
   <data name="ExportColorHeader.Text" xml:space="preserve">
     <value>Cor predefinida</value>
   </data>
   <data name="ExportGlyphFormatDescription.Text" xml:space="preserve">
-    <value>Os glyphs armazenados em formatos binários serão exportados como o seu formato nativo, independentemente desta escolha.</value>
+    <value>Os glifos armazenados em formato binário serão exportados no seu formato nativo, independentemente desta escolha.</value>
   </data>
   <data name="ExportGlyphSelectedCharacters.Text" xml:space="preserve">
-    <value>{0} de {1} carateres selecionado(s)</value>
+    <value>{0} de {1} caracteres selecionados</value>
   </data>
   <data name="ExportFileOptionsHeader.Text" xml:space="preserve">
-    <value>Opções de Ficheiros</value>
+    <value>Opções do ficheiro</value>
   </data>
   <data name="ExportSkipBlank.Content" xml:space="preserve">
-    <value>Ignorar exportação de glyphs sem conteúdo visível</value>
+    <value>Ignorar a exportação de glifos sem conteúdo perceptível</value>
+  </data>
+  <data name="CharacterFilterButton.Label" xml:space="preserve">
+    <value>Filtrar</value>
+    <comment>Labels must be as short as possible</comment>
+  </data>
+  <data name="CollectionExportButton.Label" xml:space="preserve">
+    <value>Exportar</value>
+    <comment>Labels must be as short as possible</comment>
+  </data>
+  <data name="DeleteCollectionButton.Label" xml:space="preserve">
+    <value>Eliminar</value>
+    <comment>Labels must be as short as possible</comment>
+  </data>
+  <data name="FontOptionsButton.Label" xml:space="preserve">
+    <value>Opções</value>
+    <comment>Labels must be as short as possible</comment>
+  </data>
+  <data name="FontPropertiesButton.Label" xml:space="preserve">
+    <value>Info</value>
+    <comment>Labels must be as short as possible</comment>
+  </data>
+  <data name="OpenFontButton.Label" xml:space="preserve">
+    <value>Abrir</value>
+    <comment>Labels must be as short as possible</comment>
+  </data>
+  <data name="RenameCollectionButton.Label" xml:space="preserve">
+    <value>Renomear</value>
+    <comment>Labels must be as short as possible</comment>
+  </data>
+  <data name="SettingsDesignStyle.Description" xml:space="preserve">
+    <value>Alterar o estilo de desenho da aplicação.
+Verá a sua alteração quando voltar a iniciar a aplicação.</value>
+  </data>
+  <data name="SettingsDesignStyle.Title" xml:space="preserve">
+    <value>Estilo de desenho</value>
+  </data>
+  <data name="ViewToggleButton.Label" xml:space="preserve">
+    <value>Mudar</value>
+    <comment>Labels must be as short as possible</comment>
+  </data>
+  <data name="AddTooButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
+    <value>Adicionar à coleção</value>
+  </data>
+  <data name="ClearSelectionLabel" xml:space="preserve">
+    <value>Limpar seleção</value>
+  </data>
+  <data name="CreateNewButton.Content" xml:space="preserve">
+    <value>Criar nova</value>
+  </data>
+  <data name="OrLabel.Text" xml:space="preserve">
+    <value>ou</value>
+  </data>
+  <data name="RemoveFromButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
+    <value>Remover da coleção</value>
+  </data>
+  <data name="SelectCollectionLabel" xml:space="preserve">
+    <value>Selecionar coleção</value>
+  </data>
+  <data name="SettingsCollectionsHeader" xml:space="preserve">
+    <value>Coleções</value>
+  </data>
+  <data name="DigOpenFolder.PrimaryButtonText" xml:space="preserve">
+    <value>Abrir tipos de letra</value>
+  </data>
+  <data name="DigOpenFolder.SecondaryButtonText" xml:space="preserve">
+    <value>Cancelar</value>
+  </data>
+  <data name="DigOpenFolder.Title" xml:space="preserve">
+    <value>Abrir pasta com tipos de letra</value>
+  </data>
+  <data name="DigOpenFolderContent.CheckRecursiveContent" xml:space="preserve">
+    <value>Incluir pastas subordinadas</value>
+  </data>
+  <data name="DigOpenFolderContent.CheckZipContent" xml:space="preserve">
+    <value>Incluir ficheiros comprimidos ZIP</value>
+  </data>
+  <data name="DigOpenFolderContent.FindDescription" xml:space="preserve">
+    <value>Ativar opções poder aumentar drasticamente o tempo necessário para abrir a pasta</value>
+  </data>
+  <data name="DigOpenFolderContent.FindHeader" xml:space="preserve">
+    <value>Opções de procura</value>
+  </data>
+  <data name="DigOpenFolderContent.FindingFontsLabel" xml:space="preserve">
+    <value>A procurar tipos de letra...</value>
+  </data>
+  <data name="DigOpenFolderContent.PrefixLabel" xml:space="preserve">
+    <value>Encontrou</value>
+  </data>
+  <data name="DigOpenFolderContent.SelectHeader" xml:space="preserve">
+    <value>Pasta selecionada (premir para mudar)</value>
+  </data>
+  <data name="DigOpenFolderContent.SuffixLabel" xml:space="preserve">
+    <value>ficheiro(s) de tipo de letra</value>
+  </data>
+  <data name="FontFileMenuItem.Text" xml:space="preserve">
+    <value>Abrir tipo de letra</value>
+  </data>
+  <data name="FontFolderMenuItem.Text" xml:space="preserve">
+    <value>Abrir pasta</value>
+  </data>
+  <data name="AddHistoryButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
+    <value>Adicionar ao histórico</value>
+  </data>
+  <data name="CalligraphyLabel.Text" xml:space="preserve">
+    <value>Caligrafia</value>
+  </data>
+  <data name="ClearAllButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
+    <value>Limpar tudo</value>
+  </data>
+  <data name="ClearAllItem.Text" xml:space="preserve">
+    <value>Limpar tudo</value>
+  </data>
+  <data name="GuideToggle.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
+    <value>Mostrar guias</value>
+  </data>
+  <data name="HistoryLabel.Text" xml:space="preserve">
+    <value>Histórico</value>
+  </data>
+  <data name="RedoButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
+    <value>Refazer (Ctrl+Y)</value>
+  </data>
+  <data name="RemoveButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
+    <value>Remover</value>
+  </data>
+  <data name="SaveButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
+    <value>Guardar (Ctrl+S)</value>
+  </data>
+  <data name="SideBySideToggle.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
+    <value>Lado a lado</value>
+  </data>
+  <data name="UndoButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
+    <value>Anular (Ctrl+Z)</value>
+  </data>
+  <data name="GuideFontSlider.Header" xml:space="preserve">
+    <value>Tamanho da guia</value>
+  </data>
+  <data name="CharacterPickerButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
+    <value>Abrir seleccionador de caracteres</value>
+  </data>
+  <data name="GuideHeaderLabel.Text" xml:space="preserve">
+    <value>Texto da guia</value>
+  </data>
+  <data name="GuideSizeLabel.Text" xml:space="preserve">
+    <value>Tamanho da guia</value>
+  </data>
+  <data name="MenuToggle.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
+    <value>Mostrar ou ocultar painel de tipos de letra (Ctrl+L)</value>
+  </data>
+  <data name="OpenInNewTab.Text" xml:space="preserve">
+    <value>Abrir num separador novo</value>
+  </data>
+  <data name="OptionScriptKorean.Text" xml:space="preserve">
+    <value>Coreano</value>
+  </data>
+  <data name="AddActiveToCollectionItem.Text" xml:space="preserve">
+    <value>Adicionar activos à Coleção</value>
+  </data>
+  <data name="CompareActiveItem.Text" xml:space="preserve">
+    <value>Comparar os tipos de letra activos</value>
+  </data>
+  <data name="OptionEmoji.Text" xml:space="preserve">
+    <value>Emoji</value>
+  </data>
+  <data name="OptionSupportedScripts.Text" xml:space="preserve">
+    <value>Escritas suportadas</value>
+  </data>
+  <data name="CompareFontFaceTitle.Text" xml:space="preserve">
+    <value>A comparar tipos de letra</value>
+  </data>
+  <data name="CompareFacesCountLabel.Text" xml:space="preserve">
+    <value>Comparar {0} tipos de letra</value>
+  </data>
+  <data name="CompareFamilyTitle.Text" xml:space="preserve">
+    <value>A comparar {0}</value>
+  </data>
+  <data name="MenuButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
+    <value>Abrir menu</value>
+  </data>
+  <data name="FontsSelectedCountLabel" xml:space="preserve">
+    <value>{0} tipo(s) de letra, {1} selecionado(s)</value>
+  </data>
+  <data name="CompareShortLabel" xml:space="preserve">
+    <value>Comparar</value>
+  </data>
+  <data name="AllFontsLabel.Text" xml:space="preserve">
+    <value>Todos os tipos de letra</value>
+  </data>
+  <data name="ImportLabel.Text" xml:space="preserve">
+    <value>Importar</value>
+  </data>
+  <data name="PreferredFormatGroup.Text" xml:space="preserve">
+    <value>Formato preferencial</value>
+    <comment>Preferred export format</comment>
+  </data>
+  <data name="RemoveLabel.Text" xml:space="preserve">
+    <value>Remover</value>
+  </data>
+  <data name="UndoLabel" xml:space="preserve">
+    <value>Anular</value>
+  </data>
+  <data name="CalligraphyDescription.Text" xml:space="preserve">
+    <value>Praticar a escrita no estilo do tipo de letra atual</value>
+  </data>
+  <data name="CompareFontsDescription.Text" xml:space="preserve">
+    <value>Veja e compare todos os seus tipos de letra lado-a-lado</value>
+  </data>
+  <data name="DoMoreLabel.Text" xml:space="preserve">
+    <value>Efectuar mais</value>
+  </data>
+  <data name="FullscreenLabel.Text" xml:space="preserve">
+    <value>Ecrã inteiro</value>
+  </data>
+  <data name="OpenFolderDescription.Text" xml:space="preserve">
+    <value>Abrir todos os tipos de letra dentro da pasta</value>
+  </data>
+  <data name="OpenFontDescription.Text" xml:space="preserve">
+    <value>Abrir ficheiros TTF, OTF, OTC, TTC, WOFF, WOFF2 ou ZIP</value>
+  </data>
+  <data name="SettingsPointerOverAnimation.Description" xml:space="preserve">
+    <value>Ativa animações subtis de ressalto sempre que o ponteiro do rato passa sobre determinados botões.</value>
+  </data>
+  <data name="SettingsPointerOverAnimation.Title" xml:space="preserve">
+    <value>Animções sob o ponteiro do rato</value>
+  </data>
+  <data name="SettingsCustomSuggestions.Description" xml:space="preserve">
+    <value>Adiciona e organiza sugestões de texto personalizadas para mostrar na visualização Rampa e na janela de Comparação.
+Tocar e manter premido para organizar.</value>
+  </data>
+  <data name="SettingsCustomSuggestions.Title" xml:space="preserve">
+    <value>Opções personalizadas</value>
+  </data>
+  <data name="SettingsSuggestionsHeader.Text" xml:space="preserve">
+    <value>Pré-visualizar sugestões</value>
+  </data>
+  <data name="SettingsSuggestionTextBox.PlaceholderText" xml:space="preserve">
+    <value>Introduz a tua sugestão aqui</value>
+  </data>
+  <data name="FontPropPanoseTitle.Text" xml:space="preserve">
+    <value>Valores PANOSE</value>
+  </data>
+  <data name="CharacterGroupingToggle.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
+    <value>Agrupar caracteres por intervalo de Unicode (Ctrl+G)</value>
+  </data>
+  <data name="PixelUnits.Text" xml:space="preserve">
+    <value>px</value>
+  </data>
+  <data name="SettingsCharGrouping.Description" xml:space="preserve">
+    <value>Se estiver ativado, os caracteres são agrupados por intervalo de Unicode no mapa de caracteres, caso contrário eles são mostrados numa única lista desagrupada.</value>
+  </data>
+  <data name="SettingsCharGrouping.Title" xml:space="preserve">
+    <value>Agrupar caracteres</value>
+  </data>
+  <data name="CopyAsImageItem.Text" xml:space="preserve">
+    <value>Copiar como imagem</value>
+  </data>
+  <data name="CopyAsPngItem.Text" xml:space="preserve">
+    <value>Copiar como PNG</value>
+  </data>
+  <data name="CopyAsSvgItem.Text" xml:space="preserve">
+    <value>Copiar como SVG</value>
+  </data>
+  <data name="NotificationCopiedPNG" xml:space="preserve">
+    <value>Copiado como PNG</value>
+  </data>
+  <data name="NotificationCopiedSVG" xml:space="preserve">
+    <value>Copiado como SVG</value>
+  </data>
+  <data name="ColrV1SupportMessage.Text" xml:space="preserve">
+    <value>Este tipo de letra contém glifos COLRv1. Para os pré-visualizar com a composição adequada, mude para a visualização Rampa utilizando o botão acima.</value>
+  </data>
+  <data name="FontPropCOLRVersion.Text" xml:space="preserve">
+    <value>Versão COLR</value>
+  </data>
+  <data name="FontPropColourFormats.Text" xml:space="preserve">
+    <value>Formatos de glifos coloridos</value>
+  </data>
+  <data name="GlyphTypeBitmap" xml:space="preserve">
+    <value>Mapa de bits</value>
+  </data>
+  <data name="TypeRampFlowButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
+    <value>Alterar sentido do fluxo</value>
+  </data>
+  <data name="TxtUniCodepoint.Header" xml:space="preserve">
+    <value>Ponto de código Unicode</value>
+  </data>
+  <data name="TxtUTF16.Header" xml:space="preserve">
+    <value>Valor UTF-16</value>
+  </data>
+  <data name="EditSuggestionsItem.Text" xml:space="preserve">
+    <value>Editar sugestões</value>
+  </data>
+  <data name="OptionScriptHiraganaAndKatakana.Text" xml:space="preserve">
+    <value>Hiragana &amp; Katakana</value>
+  </data>
+  <data name="OptionsScriptBengali.Text" xml:space="preserve">
+    <value>Bangla</value>
+  </data>
+  <data name="OptionsScriptDevanagari.Text" xml:space="preserve">
+    <value>Devanágari</value>
+  </data>
+  <data name="BtnTextClose.Content" xml:space="preserve">
+    <value>Fechar</value>
+  </data>
+  <data name="EditSuggestionsLabel.Text" xml:space="preserve">
+    <value>Editar sugestões personalizadas</value>
+  </data>
+  <data name="ShowSuggestionsButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
+    <value>Mostrar sugestões</value>
+  </data>
+  <data name="SuggestOptionArabic.Text" xml:space="preserve">
+    <value>Árabe</value>
+  </data>
+  <data name="SuggestOptionBengali.Text" xml:space="preserve">
+    <value>Bangla</value>
+  </data>
+  <data name="SuggestOptionBulgarian.Text" xml:space="preserve">
+    <value>Búlgaro</value>
+  </data>
+  <data name="SuggestOptionChineseTraditional.Text" xml:space="preserve">
+    <value>Chinês (Tradicional)</value>
+  </data>
+  <data name="SuggestOptionCultureSpecific.Text" xml:space="preserve">
+    <value>Português</value>
+  </data>
+  <data name="SuggestOptionCustom.Text" xml:space="preserve">
+    <value>Personalizada</value>
+  </data>
+  <data name="SuggestOptionCyrillicAlpha.Text" xml:space="preserve">
+    <value>Alfabeto cirílico</value>
+  </data>
+  <data name="SuggestOptionEmoji.Text" xml:space="preserve">
+    <value>Emoji</value>
+  </data>
+  <data name="SuggestOptionEnglish.Text" xml:space="preserve">
+    <value>Inglês</value>
+  </data>
+  <data name="SuggestOptionGreek.Text" xml:space="preserve">
+    <value>Grego</value>
+  </data>
+  <data name="SuggestOptionHebrew.Text" xml:space="preserve">
+    <value>Hebraico</value>
+  </data>
+  <data name="SuggestOptionHindi.Text" xml:space="preserve">
+    <value>Hindi</value>
+  </data>
+  <data name="SuggestOptionJapanese.Text" xml:space="preserve">
+    <value>Japonês</value>
+  </data>
+  <data name="SuggestOptionKorean.Text" xml:space="preserve">
+    <value>Coreano</value>
+  </data>
+  <data name="SuggestOptionLatinAlpha.Text" xml:space="preserve">
+    <value>Alfabeto latim</value>
+  </data>
+  <data name="SuggestOptionLatinSymbols.Text" xml:space="preserve">
+    <value>Números &amp; símbolos latim</value>
+  </data>
+  <data name="SuggestOptionSample.Text" xml:space="preserve">
+    <value>Texto de exemplo do tipo de letra</value>
+  </data>
+  <data name="SuggestOptionThai.Text" xml:space="preserve">
+    <value>Tailandês</value>
+  </data>
+  <data name="SuggestOptionVietnamese.Text" xml:space="preserve">
+    <value>Vietnamita</value>
+  </data>
+  <data name="InstallCountLabel" xml:space="preserve">
+    <value>{0} famílias tipográficas, {1} tipos de letra instalados no seu computador</value>
+  </data>
+  <data name="OptionSystemFonts.Text" xml:space="preserve">
+    <value>Tipos de letra instalados</value>
+  </data>
+  <data name="SettingsExportInstalledLabel.Text" xml:space="preserve">
+    <value>Exportar tipos de letra instalados</value>
+  </data>
+  <data name="HiddenGlyphsMessage.Text" xml:space="preserve">
+    <value>Com base nas suas definições, os ícones preteridos estão ocultos por predefinição. Utiliza o botão de filtro acima para os mostrar.</value>
+  </data>
+  <data name="InstallDialog.SecondaryButtonText" xml:space="preserve">
+    <value>Fechar</value>
+  </data>
+  <data name="InstallDialog.Title" xml:space="preserve">
+    <value>Instalar tipo de letra</value>
+  </data>
+  <data name="InstallFontInstructions.Text" xml:space="preserve">
+    <value>Leia todas as instruções antes de continuar com a instalação do tipo de letra
+
+1. Prima "Iniciar" abaixo
+2. Selecione "Visual. Letras Windows" e escolha "Apenas uma vez"
+3. Prima "Instalar" na parte superior da janela do visualizador de letras
+
+O tipo de letra da Web será convertida num formato OTF para a instalação.</value>
+    <comment>Word in such a way that encourages the user to read all the steps before continuing</comment>
+  </data>
+  <data name="InstallLabel.Text" xml:space="preserve">
+    <value>Instalar</value>
+  </data>
+  <data name="OptionUnicodeRange/Text" xml:space="preserve">
+    <value>Por intervalo Unicode</value>
+  </data>
+  <data name="SettingsAdvancedOptionsLabel.Text" xml:space="preserve">
+    <value>Avançado</value>
+  </data>
+  <data name="SettingsDeprecatedIconsPresenter.Description" xml:space="preserve">
+    <value>Se estiver ativado, oculta os ícones preteridos dos tipos de letra Segoe MDL2 e Segoe Fluent por predefinição. Os ícones ainda podem ser mostrados ao utilizar o filtro na lista de opções.
+
+Não é recomendado referenciar os ícones preteridos através do código unicode, todos os ícones preteridos tem um equivalente não preterido.</value>
+  </data>
+  <data name="SettingsDeprecatedIconsPresenter.Title" xml:space="preserve">
+    <value>Esconder ícones preteridos</value>
+  </data>
+  <data name="StartLabel.Text" xml:space="preserve">
+    <value>Iniciar</value>
+  </data>
+  <data name="TxtUniHexValue.Text" xml:space="preserve">
+    <value>Valor hexadecimal</value>
+  </data>
+  <data name="FileExplorerFileToolTip" xml:space="preserve">
+    <value>Pré-visualizar ficheiro</value>
+  </data>
+  <data name="ImportCountLabel" xml:space="preserve">
+    <value>{0} família(s) tipográfica(s), {1} tipo(s) de letra importado(s)</value>
+  </data>
+  <data name="SettingsFontExportVersionLabel.Text" xml:space="preserve">
+    <value>Incluir número da versão no nome do ficheiro</value>
+  </data>
+  <data name="HideUnihanLabel.Text" xml:space="preserve">
+    <value>Ocultar dados Unihan</value>
+  </data>
+  <data name="ShowUnihanLabel.Text" xml:space="preserve">
+    <value>Mostrar dados Unihan</value>
+  </data>
+  <data name="UnihanDefinition.Text" xml:space="preserve">
+    <value>Definição</value>
+  </data>
+  <data name="UnihanPronunciations.Text" xml:space="preserve">
+    <value>Pronunciações</value>
+  </data>
+  <data name="UnihanTypeDescriptionCantonese" xml:space="preserve">
+    <value>A leitura mais frequente em jyutping (cantonês) para este ideograma.</value>
+  </data>
+  <data name="UnihanTypeDescriptionHangul" xml:space="preserve">
+    <value>Pronúncia(s) de coreano moderno deste ideograma em hangul, com a(s) sua(s) fonte(s) entre parênteses.</value>
+  </data>
+  <data name="UnihanTypeDescriptionHanyuPinlu" xml:space="preserve">
+    <value>Pronúncia(s) e frequência(s) deste ideograma, em parte com base em aparecerem no 《現代漢語頻率詞典》 &lt;Xiandai Hanyu Pinlu Cidian&gt;</value>
+  </data>
+  <data name="UnihanTypeDescriptionJapanese" xml:space="preserve">
+    <value>A leitura deste ideograma, expressa em Kana, em japonês. 
+
+As leituras expressas em hiragana são, geralmente, consideradas Kun-yomi (訓読み), e as expressas em katakana são, geralmente, consideradas On-yomi (音読み).</value>
+  </data>
+  <data name="UnihanTypeDescriptionJapaneseKun" xml:space="preserve">
+    <value>Pronúncia(s) de japonês para este ideograma na romanização Hepburn.</value>
+  </data>
+  <data name="UnihanTypeDescriptionJapaneseOn" xml:space="preserve">
+    <value>Pronúncia(s) de sino-japonês para este ideograma.</value>
+  </data>
+  <data name="UnihanTypeDescriptionKorean" xml:space="preserve">
+    <value>Pronúncia(s) do ideograma em coreano, utilizando o sistema de romanização de Yale.</value>
+  </data>
+  <data name="UnihanTypeDescriptionMandarin" xml:space="preserve">
+    <value>A leitura mais frequente deste ideograma em pīnyīn. 
+
+Assim que existir dois valores, o chinês simplificado (zh-Hans (CN)) é o primeiro valor preferido seguido do chinês tradicional (zh-Hant (TW)). 
+
+Quando existe apenas um valor, ele é adequado para ambos.</value>
+  </data>
+  <data name="UnihanTypeDescriptionTang" xml:space="preserve">
+    <value>A(s) pronúncia(s) deste ideograma na dinastia Tang, derivada ou consistente com o T’ang Poetic Vocabulary por Hugh M. Stimson, Far Eastern Publications, Yale University 1976.</value>
+  </data>
+  <data name="UnihanTypeDescriptionTGHZ2013" xml:space="preserve">
+    <value>Uma ou mais leituras de Hànyǔ Pīnyīn conforme indicado no Tōngyòng Guīfàn Hànzì Zìdiǎn.</value>
+  </data>
+  <data name="UnihanTypeDescriptionVietnamese" xml:space="preserve">
+    <value>Pronúncia(s) do ideograma em Quốc ngữ.</value>
+  </data>
+  <data name="UnihanTypeDescriptionXHC1983" xml:space="preserve">
+    <value>Uma ou mais leituras de Hànyǔ Pīnyīn conforme indicado no Xiàndài Hànyǔ Cídiǎn</value>
+  </data>
+  <data name="UnihanTypeNameCantonese" xml:space="preserve">
+    <value>Cantonês</value>
+  </data>
+  <data name="UnihanTypeNameHangul" xml:space="preserve">
+    <value>Hangul</value>
+  </data>
+  <data name="UnihanTypeNameJapanese" xml:space="preserve">
+    <value>Japonês</value>
+  </data>
+  <data name="UnihanTypeNameJapaneseKun" xml:space="preserve">
+    <value>Japonês Kun</value>
+  </data>
+  <data name="UnihanTypeNameJapaneseOn" xml:space="preserve">
+    <value>Japonês On</value>
+  </data>
+  <data name="UnihanTypeNameKorean" xml:space="preserve">
+    <value>Coreano</value>
+  </data>
+  <data name="UnihanTypeNameMandarin" xml:space="preserve">
+    <value>Mandarim</value>
+  </data>
+  <data name="UnihanTypeNameVietnamese" xml:space="preserve">
+    <value>Vietnamita</value>
+  </data>
+  <data name="HiddenSearchResultsLabel.Text" xml:space="preserve">
+    <value>OCULTO</value>
+  </data>
+  <data name="NotificationSearchSelectedCharHidden" xml:space="preserve">
+    <value>O carácter selecionado está atualmente oculto pelo seu filtro selecionado</value>
+  </data>
+  <data name="SuggestOptionChineseSimplified.Text" xml:space="preserve">
+    <value>Chinês (Simplificado)</value>
+  </data>
+  <data name="CollectionManagementHint.Text" xml:space="preserve">
+    <value>Cria coleções para comparar, exportar ou gerir vários tipos de letra de uma só vez. Para começar, acima selecione uma coleção existente ou crie uma nova.</value>
+  </data>
+  <data name="CollectionSelector.PlaceholderText" xml:space="preserve">
+    <value>Escolher existente</value>
+  </data>
+  <data name="FindCharButton.Text" xml:space="preserve">
+    <value>Procurar noutros tipos de letra</value>
+  </data>
+  <data name="FontFamilyFilterInput.PlaceholderText" xml:space="preserve">
+    <value>Filtrar por família</value>
+  </data>
+  <data name="SettingsRememberFilter.Description" xml:space="preserve">
+    <value>Se esta opção estiver ativada, vai ser guardada a última coleção ou filtro selecionado e vai ser restaurada quando voltar a iniciar a aplicação. 
+
+Caso contrário, "Todos os tipos de letra" é selecionado por predefinição em todos os inícios.</value>
+  </data>
+  <data name="SettingsRememberFilter.Title" xml:space="preserve">
+    <value>Memorizar o filtro da lista dos tipos de letra selecionados entre sessões</value>
+  </data>
+  <data name="GlyphNameToggleHeader.Text" xml:space="preserve">
+    <value>Modelo de nome de ficheiro</value>
+  </data>
+  <data name="GlyphNameToggleLabel.Text" xml:space="preserve">
+    <value>Mostrar partes do modelo</value>
+  </data>
+  <data name="FileNameWriterCharDescDesc" xml:space="preserve">
+    <value>Descrição Unicode do glifo ou, se nenhuma, cadeia Unicode</value>
+  </data>
+  <data name="FileNameWriterExtensionDesc" xml:space="preserve">
+    <value>Extensão do ficheiro</value>
+  </data>
+  <data name="FileNameWriterFaceDesc" xml:space="preserve">
+    <value>Nome da variação do tipo de letra atual</value>
+  </data>
+  <data name="FileNameWriterFamilyDesc" xml:space="preserve">
+    <value>Nome da família do tipo de letra</value>
+  </data>
+  <data name="FileNameWriterPixelSizeDesc" xml:space="preserve">
+    <value>Tamanho em píxeis</value>
+  </data>
+  <data name="FileNameWriterStringFormat" xml:space="preserve">
+    <value>{0}, ex. {1}</value>
+  </data>
+  <data name="FileNameWriterUnicodeCPDesc" xml:space="preserve">
+    <value>Índice Unicode/valor ponto de código</value>
+  </data>
+  <data name="FileNameWriterUnicodeHexDesc" xml:space="preserve">
+    <value>Valor hexadecimal Unicode</value>
+  </data>
+  <data name="FileNameWriterXamlGlyphDesc" xml:space="preserve">
+    <value>Código de glifo XAML</value>
+  </data>
+  <data name="SettingsGlyphNaming.Description" xml:space="preserve">
+    <value>Escolha o nome dos ficheiros de caracteres exportados.</value>
+  </data>
+  <data name="SettingsGlyphNaming.Title" xml:space="preserve">
+    <value>Nomenclatura da exportação de glifos</value>
+  </data>
+  <data name="ExampleFormat" xml:space="preserve">
+    <value>ex. {0}</value>
+  </data>
+  <data name="FileNameWriterFontVerDesc" xml:space="preserve">
+    <value>Se aplicável, o numéro da versão do tipo de letra</value>
+  </data>
+  <data name="CanvasFontInformationCopyrightNotice" xml:space="preserve">
+    <value>Direitos de autor</value>
+  </data>
+  <data name="CanvasFontInformationDescription" xml:space="preserve">
+    <value>Descrição</value>
+  </data>
+  <data name="CanvasFontInformationDesigner" xml:space="preserve">
+    <value>Autor</value>
+  </data>
+  <data name="CanvasFontInformationDesignerUrl" xml:space="preserve">
+    <value>URL do autor</value>
+  </data>
+  <data name="CanvasFontInformationFontVendorUrl" xml:space="preserve">
+    <value>URL do fornecedor do tipo de letra</value>
+  </data>
+  <data name="CanvasFontInformationFullName" xml:space="preserve">
+    <value>Nome completo</value>
+  </data>
+  <data name="CanvasFontInformationLicenseDescription" xml:space="preserve">
+    <value>Licença</value>
+  </data>
+  <data name="CanvasFontInformationLicenseInfoUrl" xml:space="preserve">
+    <value>URL da licença</value>
+  </data>
+  <data name="CanvasFontInformationManufacturer" xml:space="preserve">
+    <value>Empresa</value>
+  </data>
+  <data name="CanvasFontInformationTrademark" xml:space="preserve">
+    <value>Marca registada</value>
+  </data>
+  <data name="RestoreLabel.Text" xml:space="preserve">
+    <value>Restaurar</value>
+    <comment>Opposite of Fullscreen</comment>
+  </data>
+  <data name="CharFilter" xml:space="preserve">
+    <value>car:</value>
+    <comment>Command used for character searches. Should be short.</comment>
+  </data>
+  <data name="CreateSmartCollectionCheck.Content" xml:space="preserve">
+    <value>Criar como coleção inteligente</value>
+  </data>
+  <data name="CreateSmartCollectionHint.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
+    <value>Ver online a documentação para coleções inteligentes</value>
+  </data>
+  <data name="DesignerFilter" xml:space="preserve">
+    <value>autor:</value>
+    <comment>Command used for designer searches. Should be short.</comment>
+  </data>
+  <data name="FilePathFilter" xml:space="preserve">
+    <value>caminho:</value>
+    <comment>Command used for file path searches. Should be short.</comment>
+  </data>
+  <data name="FoundryFilter" xml:space="preserve">
+    <value>empresa:</value>
+    <comment>Command used for foundry searches. Should be short.</comment>
+  </data>
+  <data name="SmartCollectionDesignerFilter.Text" xml:space="preserve">
+    <value>Filtro de autor</value>
+  </data>
+  <data name="SmartCollectionFilePathFilter.Text" xml:space="preserve">
+    <value>Fitro de caminho do ficheiro</value>
+  </data>
+  <data name="SmartCollectionFoundryFilter.Text" xml:space="preserve">
+    <value>Fitro de empresa</value>
+  </data>
+  <data name="DigEditCollection.PrimaryButtonText" xml:space="preserve">
+    <value>Editar</value>
+  </data>
+  <data name="DigEditCollection.Title" xml:space="preserve">
+    <value>Editar coleção</value>
+  </data>
+  <data name="EditCollectionButton.Label" xml:space="preserve">
+    <value>Editar</value>
+  </data>
+  <data name="EditCollectionButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
+    <value>Editar coleção</value>
+  </data>
+  <data name="BtnHelpAndTips.Content" xml:space="preserve">
+    <value>Ajuda &amp; sugestões</value>
+  </data>
+  <data name="SmartCollectionEditHint.Text" xml:space="preserve">
+    <value>Para modificar as coleções inteligentes, utilize o botão de editar acima.</value>
   </data>
 </root>

--- a/CharacterMap/CharacterMap/Strings/pt-PT/Resources.resw
+++ b/CharacterMap/CharacterMap/Strings/pt-PT/Resources.resw
@@ -1602,4 +1602,7 @@ Caso contrário, "Todos os tipos de letra" é selecionado por predefinição em 
   <data name="SmartCollectionEditHint.Text" xml:space="preserve">
     <value>Para modificar as coleções inteligentes, utilize o botão de editar acima.</value>
   </data>
+  <data name="DigOpenFolderContent.SelectFolderButtonContent" xml:space="preserve">
+    <value>Selecionar pasta</value>
+  </data>
 </root>

--- a/CharacterMap/CharacterMap/Views/PrintView.xaml
+++ b/CharacterMap/CharacterMap/Views/PrintView.xaml
@@ -14,7 +14,7 @@
     Background="Transparent"
     TabFocusNavigation="Cycle"
     mc:Ignorable="d"
-    d:DesignHeight="720"
+    d:DesignHeight="1024"
     d:DesignWidth="1280">
 
     <UserControl.Resources>
@@ -271,8 +271,11 @@
 
                                 <controls:UXComboBox
                                     x:Uid="PrintViewPageOrientation"
+                                    Margin="{StaticResource HeaderMargin}"
                                     SelectedIndex="0"
-                                    SelectionChanged="RadioButtons_SelectionChanged">
+                                    SelectionChanged="RadioButtons_SelectionChanged"
+                                    d:Header="Page Orientation"
+                                    d:PlaceholderText="Portrait">
                                     <controls:UXComboBoxItem x:Uid="CbiPageOrientationPortrait" />
                                     <controls:UXComboBoxItem x:Uid="CbiPageOrientationLandscape" />
                                 </controls:UXComboBox>

--- a/CharacterMap/CharacterMap/Views/SettingsView.xaml
+++ b/CharacterMap/CharacterMap/Views/SettingsView.xaml
@@ -832,8 +832,7 @@
 
                                         <Grid
                                             x:Name="ImportFontsRegion"
-                                            Width="340"
-                                            Height="80"
+                                            MaxWidth="352"
                                             HorizontalAlignment="Left">
                                             <Rectangle
                                                 Opacity="0.8"
@@ -841,28 +840,28 @@
                                                 StrokeDashArray="2 2"
                                                 StrokeThickness="1" />
 
-                                            <Grid>
+                                            <Grid ColumnSpacing="12" Padding="16">
                                                 <Grid.ColumnDefinitions>
                                                     <ColumnDefinition Width="Auto" />
                                                     <ColumnDefinition Width="*" />
                                                 </Grid.ColumnDefinitions>
 
                                                 <FontIcon
-                                                    Margin="12 12 0 12"
                                                     VerticalAlignment="Top"
                                                     FontFamily="{ThemeResource SymbolThemeFontFamily}"
                                                     FontSize="30"
                                                     Glyph="&#xE1E3;" />
 
-                                                <StackPanel Grid.Column="1" Margin="12">
+                                                <StackPanel Grid.Column="1">
                                                     <TextBlock
                                                         x:Uid="ImportDragDropLabel"
                                                         FontWeight="SemiBold"
-                                                        Opacity="0.8" />
+                                                        Opacity="0.8"
+                                                        TextWrapping="Wrap" />
                                                     <TextBlock
                                                         x:Uid="ImportDragDropDescriptionLabel"
                                                         FontSize="12"
-                                                        Opacity="0.8"
+                                                        Opacity="0.6"
                                                         TextWrapping="Wrap" />
                                                 </StackPanel>
 


### PR DESCRIPTION
Restored and almost completed the Portuguese translation. Added a string for the `Selected Folder` Button on the `OpenFolderDialog` control.

Tweaked a bit the `ImportFontsRegion` Grid design (removed the fixed height to support longer strings) on Font Management `SettingsView` page.
Added a top margin to the `PrintViewPageOrientation` ComboBox for better spacing.

These two buttons have fixed width on some themes, it will be very hard for most of the languages to fit. Can either remove/relax the `Width` or add a `TextTrimming` property.

https://github.com/character-map-uwp/Character-Map-UWP/blob/e9fad9811f9b5ea831ba87bb7d50c53d51ee2548/CharacterMap/CharacterMap/Views/FontMapView.xaml#L1917
https://github.com/character-map-uwp/Character-Map-UWP/blob/e9fad9811f9b5ea831ba87bb7d50c53d51ee2548/CharacterMap/CharacterMap/Views/FontMapView.xaml#L2011-L2012

### Preview
![Main Page](https://github.com/character-map-uwp/Character-Map-UWP/assets/698155/938df9cb-ce35-4858-b4b3-79e28e39b2f1)

