### PR TITLE
Fix deprecated glyphs and minor changes

### DIFF
--- a/CharacterMap/CharacterMap/Controls/FilterFlyout.xaml
+++ b/CharacterMap/CharacterMap/Controls/FilterFlyout.xaml
@@ -19,7 +19,10 @@
                 Foreground="{ThemeResource MenuFlyoutSeparatorThemeBrush}"
                 Text="{core:Localizer Key=SortedByRangeLabel/Text}" />
             <controls:UXButton x:Uid="ChangeSortToggle" core:Properties.ToolTipStyleKey="DefaultThemeToolTipStyle">
-                <TextBlock FontFamily="{StaticResource SymbolThemeFontFamily}" Text="&#xE8CB;" />
+                <TextBlock
+                    FontFamily="{StaticResource SymbolThemeFontFamily}"
+                    IsTextScaleFactorEnabled="False"
+                    Text="&#xE8CB;" />
             </controls:UXButton>
         </controls:AutoGrid>
     </controls:FilterFlyout.UnicodeRangeSortHeader>

--- a/CharacterMap/CharacterMap/Styles/ComboBox.xaml
+++ b/CharacterMap/CharacterMap/Styles/ComboBox.xaml
@@ -222,7 +222,7 @@
                             FontFamily="{ThemeResource SymbolThemeFontFamily}"
                             FontSize="12"
                             Foreground="{ThemeResource ComboBoxDropDownGlyphForeground}"
-                            Glyph="&#xE0E5;"
+                            Glyph="&#xE70D;"
                             IsHitTestVisible="False" />
 
                         <Popup x:Name="Popup">
@@ -624,7 +624,7 @@
                             FontFamily="{ThemeResource SymbolThemeFontFamily}"
                             FontSize="12"
                             Foreground="{ThemeResource ComboBoxDropDownGlyphForeground}"
-                            Glyph="&#xE0E5;"
+                            Glyph="&#xE70D;"
                             IsHitTestVisible="False" />
 
                         <Popup x:Name="Popup">

--- a/CharacterMap/CharacterMap/Styles/TabViewFluent.xaml
+++ b/CharacterMap/CharacterMap/Styles/TabViewFluent.xaml
@@ -360,7 +360,7 @@
                                                 <controls:FontIconSource
                                                     FontFamily="{StaticResource SymbolThemeFontFamily}"
                                                     FontSize="{Binding ElementName=CollectionButton, Path=FontSize}"
-                                                    Glyph="&#xE099;" />
+                                                    Glyph="&#xE70D;" />
                                             </controls:AnimatedIcon.FallbackIconSource>
                                         </controls:AnimatedIcon>
                                     </Button.Content>
@@ -368,12 +368,12 @@
                                         <MenuFlyout Placement="Bottom">
                                             <MenuFlyoutItem x:Uid="CompareActiveItem" Style="{StaticResource ThemeMenuFlyoutItemStyle}">
                                                 <MenuFlyoutItem.Icon>
-                                                    <FontIcon Glyph="&#xE1D3;" />
+                                                    <FontIcon Glyph="&#xE8F1;" />
                                                 </MenuFlyoutItem.Icon>
                                             </MenuFlyoutItem>
                                             <MenuFlyoutSubItem x:Uid="AddActiveToCollectionItem" Style="{StaticResource ThemeMenuFlyoutSubItemStyle}">
                                                 <MenuFlyoutSubItem.Icon>
-                                                    <FontIcon Glyph="&#xE1DA;" />
+                                                    <FontIcon Glyph="&#xE8F4;" />
                                                 </MenuFlyoutSubItem.Icon>
                                             </MenuFlyoutSubItem>
                                         </MenuFlyout>

--- a/CharacterMap/CharacterMap/Styles/TextBox.xaml
+++ b/CharacterMap/CharacterMap/Styles/TextBox.xaml
@@ -148,7 +148,8 @@
                                                     FontSize="{ThemeResource AutoSuggestBoxIconFontSize}"
                                                     FontStyle="Normal"
                                                     Foreground="{ThemeResource TextControlButtonForeground}"
-                                                    Text="&#xE10A;" />
+                                                    IsTextScaleFactorEnabled="False"
+                                                    Text="&#xE711;" />
                                             </Grid>
                                         </ControlTemplate>
                                     </Setter.Value>
@@ -276,7 +277,7 @@
                                 FontFamily="{ThemeResource SymbolThemeFontFamily}"
                                 FontSize="12"
                                 Foreground="{ThemeResource TextControlPlaceholderForeground}"
-                                Glyph="&#xE11A;" />
+                                Glyph="&#xE721;" />
 
                             <ContentControl
                                 x:Name="PlaceholderTextContent"
@@ -394,7 +395,8 @@
                                                     FontSize="{ThemeResource AutoSuggestBoxIconFontSize}"
                                                     FontStyle="Normal"
                                                     Foreground="{ThemeResource TextControlButtonForeground}"
-                                                    Text="&#xE10A;" />
+                                                    IsTextScaleFactorEnabled="False"
+                                                    Text="&#xE711;" />
                                             </Grid>
                                         </ControlTemplate>
                                     </Setter.Value>

--- a/CharacterMap/CharacterMap/Themes/ClassicThemeStyles.xaml
+++ b/CharacterMap/CharacterMap/Themes/ClassicThemeStyles.xaml
@@ -805,7 +805,7 @@
                             FontFamily="{ThemeResource SymbolThemeFontFamily}"
                             FontSize="10"
                             Foreground="{ThemeResource ComboBoxDropDownGlyphForeground}"
-                            Glyph="&#xE0E5;"
+                            Glyph="&#xE70D;"
                             IsHitTestVisible="False"
                             Visibility="Collapsed" />
                     </Grid>
@@ -1393,7 +1393,7 @@
                                 HorizontalAlignment="Right"
                                 Style="{StaticResource DefaultThemeAppBarButtonStyle}"
                                 Visibility="{TemplateBinding CloseButtonVisibility}">
-                                <FontIcon Glyph="&#xE10A;" />
+                                <FontIcon Glyph="&#xE711;" />
                                 <Button.KeyboardAccelerators>
                                     <KeyboardAccelerator Key="Escape" Modifiers="None" />
                                 </Button.KeyboardAccelerators>
@@ -1899,7 +1899,7 @@
                             FontFamily="{ThemeResource SymbolThemeFontFamily}"
                             FontSize="8"
                             Foreground="{TemplateBinding Foreground}"
-                            Glyph="&#xE0E5;"
+                            Glyph="&#xE70D;"
                             IsHitTestVisible="False" />
                         <ContentPresenter
                             x:Name="DescriptionPresenter"
@@ -2184,7 +2184,7 @@
                             FontFamily="{ThemeResource SymbolThemeFontFamily}"
                             FontSize="8"
                             Foreground="{TemplateBinding Foreground}"
-                            Glyph="&#xE0E5;"
+                            Glyph="&#xE70D;"
                             IsHitTestVisible="False" />
 
                         <Popup x:Name="Popup">
@@ -3020,7 +3020,8 @@
                                                     FontSize="{ThemeResource AutoSuggestBoxIconFontSize}"
                                                     FontStyle="Normal"
                                                     Foreground="{ThemeResource TextControlButtonForeground}"
-                                                    Text="&#xE10A;" />
+                                                    IsTextScaleFactorEnabled="False"
+                                                    Text="&#xE711;" />
                                             </Grid>
                                         </ControlTemplate>
                                     </Setter.Value>
@@ -3229,7 +3230,7 @@
                                 FontFamily="{ThemeResource SymbolThemeFontFamily}"
                                 FontSize="12"
                                 Foreground="{ThemeResource TextControlPlaceholderForeground}"
-                                Glyph="&#xE11A;" />
+                                Glyph="&#xE721;" />
                             <ContentControl
                                 x:Name="PlaceholderTextContent"
                                 Content="{TemplateBinding PlaceholderText}"

--- a/CharacterMap/CharacterMap/Themes/DefaultThemeStyles.xaml
+++ b/CharacterMap/CharacterMap/Themes/DefaultThemeStyles.xaml
@@ -355,7 +355,7 @@
                             FontFamily="{ThemeResource SymbolThemeFontFamily}"
                             FontSize="12"
                             Foreground="{ThemeResource ComboBoxDropDownGlyphForeground}"
-                            Glyph="&#xE0E5;"
+                            Glyph="&#xE70D;"
                             IsHitTestVisible="False"
                             Visibility="Collapsed" />
                     </Grid>
@@ -1263,7 +1263,7 @@
                             FontFamily="{ThemeResource SymbolThemeFontFamily}"
                             FontSize="12"
                             Foreground="{ThemeResource ComboBoxDropDownGlyphForeground}"
-                            Glyph="&#xE0E5;"
+                            Glyph="&#xE70D;"
                             IsHitTestVisible="False" />
                         <ContentPresenter
                             x:Name="DescriptionPresenter"
@@ -1537,7 +1537,7 @@
                             FontFamily="{ThemeResource SymbolThemeFontFamily}"
                             FontSize="12"
                             Foreground="{ThemeResource ComboBoxDropDownGlyphForeground}"
-                            Glyph="&#xE0E5;"
+                            Glyph="&#xE70D;"
                             IsHitTestVisible="False" />
 
                         <Popup
@@ -2392,7 +2392,8 @@
                                                     FontSize="{ThemeResource AutoSuggestBoxIconFontSize}"
                                                     FontStyle="Normal"
                                                     Foreground="{ThemeResource TextControlButtonForeground}"
-                                                    Text="&#xE10A;" />
+                                                    IsTextScaleFactorEnabled="False"
+                                                    Text="&#xE711;" />
                                             </Grid>
                                         </ControlTemplate>
                                     </Setter.Value>
@@ -2600,7 +2601,7 @@
                                 FontFamily="{ThemeResource SymbolThemeFontFamily}"
                                 FontSize="12"
                                 Foreground="{ThemeResource TextControlPlaceholderForeground}"
-                                Glyph="&#xE11A;" />
+                                Glyph="&#xE721;" />
                             <ContentControl
                                 x:Name="PlaceholderTextContent"
                                 Content="{TemplateBinding PlaceholderText}"

--- a/CharacterMap/CharacterMap/Themes/FluentThemeStyles.xaml
+++ b/CharacterMap/CharacterMap/Themes/FluentThemeStyles.xaml
@@ -1513,7 +1513,7 @@
                                 FontFamily="{ThemeResource SymbolThemeFontFamily}"
                                 FontSize="12"
                                 Foreground="{ThemeResource ComboBoxDropDownGlyphForeground}"
-                                Glyph="&#xE0E5;"
+                                Glyph="&#xE70D;"
                                 IsHitTestVisible="False" />
 
                         </Grid>
@@ -1710,7 +1710,7 @@
                                         FontFamily="{ThemeResource SymbolThemeFontFamily}"
                                         FontSize="12"
                                         Foreground="{ThemeResource ComboBoxDropDownGlyphForeground}"
-                                        Glyph="&#xE0E5;" />
+                                        Glyph="&#xE70D;" />
                                 </muxc:AnimatedIcon.FallbackIconSource>
                             </muxc:AnimatedIcon>
 
@@ -2159,7 +2159,7 @@
                                 FontFamily="{ThemeResource SymbolThemeFontFamily}"
                                 FontSize="12"
                                 Foreground="{Binding ElementName=PlaceholderTextContent, Path=Foreground}"
-                                Glyph="&#xE11A;" />
+                                Glyph="&#xE721;" />
                             <ContentControl
                                 x:Name="PlaceholderTextContent"
                                 Content="{TemplateBinding PlaceholderText}"

--- a/CharacterMap/CharacterMap/Themes/Generic.xaml
+++ b/CharacterMap/CharacterMap/Themes/Generic.xaml
@@ -271,7 +271,7 @@
                                     HorizontalAlignment="Center"
                                     VerticalAlignment="Center"
                                     Foreground="White"
-                                    Glyph="&#xE10A;" />
+                                    Glyph="&#xE711;" />
                             </controls:UXButton>
                         </Grid>
                     </Grid>
@@ -410,7 +410,7 @@
                                 h:FluentAnimation.UsePointerOver="True"
                                 Style="{StaticResource DefaultThemeAppBarButtonStyle}"
                                 Visibility="{TemplateBinding CloseButtonVisibility}">
-                                <FontIcon Glyph="&#xE10A;" />
+                                <FontIcon Glyph="&#xE711;" />
                                 <Button.KeyboardAccelerators>
                                     <KeyboardAccelerator Key="Escape" Modifiers="None" />
                                 </Button.KeyboardAccelerators>
@@ -518,7 +518,7 @@
                                         x:Uid="AppBtnSelectAll"
                                         Style="{StaticResource LabelAppBarButtonStyle}">
                                         <AppBarButton.Icon>
-                                            <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="&#xE14E;" />
+                                            <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="&#xE8B3;" />
                                         </AppBarButton.Icon>
                                     </AppBarButton>
                                     <AppBarButton
@@ -526,7 +526,7 @@
                                         x:Uid="AppBtnClear"
                                         Style="{StaticResource LabelAppBarButtonStyle}">
                                         <AppBarButton.Icon>
-                                            <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="&#xE1C5;" />
+                                            <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="&#xE8E6;" />
                                         </AppBarButton.Icon>
                                     </AppBarButton>
                                 </StackPanel>
@@ -536,7 +536,7 @@
                                     HorizontalAlignment="Right"
                                     Style="{StaticResource LabelAppBarButtonStyle}">
                                     <AppBarButton.Icon>
-                                        <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="&#xE149;" />
+                                        <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="&#xE72C;" />
                                     </AppBarButton.Icon>
                                 </AppBarButton>
                             </Grid>
@@ -1018,7 +1018,8 @@
                                     core:Properties.RotationTransition="0:0:0.2"
                                     FontFamily="{ThemeResource SymbolThemeFontFamily}"
                                     FontSize="12"
-                                    Text="&#xE019;"
+                                    IsTextScaleFactorEnabled="False"
+                                    Text="&#xE70D;"
                                     TextLineBounds="Tight" />
                             </StackPanel>
                         </Button>

--- a/CharacterMap/CharacterMap/Themes/SystemThemes.xaml
+++ b/CharacterMap/CharacterMap/Themes/SystemThemes.xaml
@@ -702,7 +702,7 @@
                 x:Name="DownSpinButton"
                 Grid.Row="1"
                 BorderThickness="1 1 0 1"
-                Content="&#xE00E;"
+                Content="&#xE76B;"
                 CornerRadius="{Binding Source={ThemeResource ControlCornerRadius}, Converter={StaticResource LeftCornerRadiusFilterConverter}}"
                 FontSize="{TemplateBinding FontSize}"
                 Style="{StaticResource NumberBoxSpinButtonStyle}" />
@@ -722,7 +722,7 @@
                 x:Name="UpSpinButton"
                 Grid.Row="1"
                 Grid.Column="2"
-                Content="&#xE00F;"
+                Content="&#xE76C;"
                 CornerRadius="{Binding Source={ThemeResource ControlCornerRadius}, Converter={StaticResource RightCornerRadiusFilterConverter}}"
                 FontSize="{TemplateBinding FontSize}"
                 Style="{StaticResource NumberBoxSpinButtonStyle}" />

--- a/CharacterMap/CharacterMap/Themes/ZuneThemeStyles.xaml
+++ b/CharacterMap/CharacterMap/Themes/ZuneThemeStyles.xaml
@@ -3059,7 +3059,8 @@
                                                     FontSize="12"
                                                     FontStyle="Normal"
                                                     Foreground="{ThemeResource TextControlButtonForeground}"
-                                                    Text="&#xE10A;" />
+                                                    IsTextScaleFactorEnabled="False"
+                                                    Text="&#xE711;" />
                                             </Grid>
                                         </ControlTemplate>
                                     </Setter.Value>
@@ -3337,7 +3338,8 @@
                                                     FontSize="{ThemeResource AutoSuggestBoxIconFontSize}"
                                                     FontStyle="Normal"
                                                     Foreground="{ThemeResource TextControlButtonForeground}"
-                                                    Text="&#xE10A;" />
+                                                    IsTextScaleFactorEnabled="False"
+                                                    Text="&#xE711;" />
                                             </Grid>
                                         </ControlTemplate>
                                     </Setter.Value>
@@ -3549,7 +3551,7 @@
                                 FontFamily="{ThemeResource SymbolThemeFontFamily}"
                                 FontSize="12"
                                 Foreground="{ThemeResource TextControlPlaceholderForeground}"
-                                Glyph="&#xE11A;" />
+                                Glyph="&#xE721;" />
 
                         </Grid>
 
@@ -4444,7 +4446,7 @@
                                 FontFamily="{ThemeResource SymbolThemeFontFamily}"
                                 FontSize="12"
                                 Foreground="{ThemeResource ComboBoxDropDownGlyphForeground}"
-                                Glyph="&#xE0E5;"
+                                Glyph="&#xE70D;"
                                 IsHitTestVisible="False" />-->
 
                         <Popup x:Name="Popup" RequestedTheme="Light">
@@ -4718,7 +4720,7 @@
                             FontFamily="{ThemeResource SymbolThemeFontFamily}"
                             FontSize="12"
                             Foreground="{ThemeResource ComboBoxDropDownGlyphForeground}"
-                            Glyph="&#xE0E5;"
+                            Glyph="&#xE70D;"
                             IsHitTestVisible="False" />
 
                         <Popup x:Name="Popup">
@@ -5274,7 +5276,7 @@
                                 FontSize="12"
                                 FontWeight="Black"
 
-                                Glyph="&#xE001;"
+                                Glyph="&#xE73E;"
                                  />-->
                         </Grid>
                         <ContentPresenter

--- a/CharacterMap/CharacterMap/Views/CalligraphyView.xaml
+++ b/CharacterMap/CharacterMap/Views/CalligraphyView.xaml
@@ -209,13 +209,13 @@
                                         x:Name="DeleteButton"
                                         x:Uid="RemoveButton"
                                         Click="DeleteButton_Click"
-                                        Content="&#xE107;"
+                                        Content="&#xE74D;"
                                         DataContext="{TemplateBinding Content}"
                                         Style="{StaticResource SmolButton}"
                                         d:ToolTipService.ToolTip="Remove" />
                                     <Button
                                         x:Uid="SaveButton"
-                                        Content="&#xE105;"
+                                        Content="&#xE74E;"
                                         DataContext="{TemplateBinding Content}"
                                         Style="{StaticResource SmolButton}"
                                         d:ToolTipService.ToolTip="Save">
@@ -382,7 +382,7 @@
                                 x:Name="UndoButton"
                                 x:Uid="UndoButton"
                                 Click="{x:Bind ViewModel.InkManager.Undo}"
-                                Content="&#xE10E;"
+                                Content="&#xE7A7;"
                                 IsEnabled="{x:Bind ViewModel.InkManager.CanUndo, Mode=OneWay, FallbackValue=False}"
                                 Style="{StaticResource SmolButton}"
                                 d:IsEnabled="False">
@@ -395,7 +395,7 @@
                                 x:Name="RedoButton"
                                 x:Uid="RedoButton"
                                 Click="{x:Bind ViewModel.InkManager.Redo}"
-                                Content="&#xE10D;"
+                                Content="&#xE7A6;"
                                 IsEnabled="{x:Bind ViewModel.InkManager.CanRedo, Mode=OneWay, FallbackValue=False}"
                                 Style="{StaticResource SmolButton}"
                                 d:IsEnabled="False">
@@ -468,7 +468,7 @@
                             <Button
                                 x:Name="ClearAllButton"
                                 x:Uid="ClearAllButton"
-                                Content="&#xE107;"
+                                Content="&#xE74D;"
                                 IsEnabled="{x:Bind ViewModel.InkManager.HasStrokes, Mode=OneWay, FallbackValue=False}"
                                 Style="{StaticResource SmolButton}"
                                 d:IsEnabled="False">
@@ -502,6 +502,7 @@
                                 <TextBlock
                                     AutomationProperties.AccessibilityView="Raw"
                                     FontFamily="{StaticResource SymbolThemeFontFamily}"
+                                    IsTextScaleFactorEnabled="False"
                                     Text="&#xE80A;" />
                             </InkToolbarCustomToggleButton>
 
@@ -530,7 +531,7 @@
                             <Button
                                 x:Name="SaveButton"
                                 x:Uid="SaveButton"
-                                Content="&#xE105;"
+                                Content="&#xE74E;"
                                 IsEnabled="{x:Bind ViewModel.InkManager.HasStrokes, Mode=OneWay, FallbackValue=False}"
                                 Style="{StaticResource SmolButton}">
                                 <Button.KeyboardAccelerators>
@@ -556,7 +557,7 @@
                                 x:Uid="AddHistoryButton"
                                 HorizontalAlignment="Right"
                                 Click="AddHistoryButton_Click"
-                                Content="&#xE109;"
+                                Content="&#xE710;"
                                 IsEnabled="{x:Bind ViewModel.InkManager.HasStrokes, Mode=OneWay, FallbackValue=False}"
                                 Style="{StaticResource SmolButton}"
                                 d:IsEnabled="False"
@@ -622,6 +623,7 @@
                             <TextBlock
                                 VerticalAlignment="Center"
                                 FontFamily="{ThemeResource SymbolThemeFontFamily}"
+                                IsTextScaleFactorEnabled="False"
                                 Text="&#xE81C;"
                                 TextLineBounds="Tight" />
                             <TextBlock

--- a/CharacterMap/CharacterMap/Views/CalligraphyView.xaml
+++ b/CharacterMap/CharacterMap/Views/CalligraphyView.xaml
@@ -451,7 +451,7 @@
                                 <InkToolbarBallpointPenButton
                                     x:Name="BallpointPen"
                                     core:Properties.ClickAnimationOffset="0.87"
-                                    core:Properties.PointerOverAnimation="Content"
+                                    core:Properties.PointerOverAnimation="Content,ContentFillGlyph"
                                     core:Properties.PointerPressedAnimation="Content|Scale"
                                     core:Properties.ToolTipStyleKey="DefaultThemeToolTipStyle"
                                     MaxStrokeWidth="10"
@@ -502,6 +502,7 @@
                                 <TextBlock
                                     AutomationProperties.AccessibilityView="Raw"
                                     FontFamily="{StaticResource SymbolThemeFontFamily}"
+                                    FontSize="16"
                                     IsTextScaleFactorEnabled="False"
                                     Text="&#xE80A;" />
                             </InkToolbarCustomToggleButton>
@@ -515,11 +516,12 @@
                                 core:Properties.PointerOverAnimation="Content"
                                 core:Properties.ToolTipStyleKey="DefaultThemeToolTipStyle"
                                 Click="Button_Click">
-                                <PathIcon
-                                    Margin="0 -4 0 0"
-                                    HorizontalAlignment="Center"
-                                    VerticalAlignment="Center"
-                                    Data="F1 M 0 7.861328 L 4.111328 3.75 L 8.75 3.75 L 8.75 16.25 L 0 16.25 Z M 3.75 5.888672 L 2.138672 7.5 L 3.75 7.5 Z M 7.5 15 L 7.5 5 L 5 5 L 5 8.75 L 1.25 8.75 L 1.25 15 Z M 15.888672 3.75 L 20 7.861328 L 20 16.25 L 11.25 16.25 L 11.25 3.75 Z M 16.25 5.888672 L 16.25 7.5 L 17.861328 7.5 Z M 12.5 15 L 18.75 15 L 18.75 8.75 L 15 8.75 L 15 5 L 12.5 5 Z " />
+                                <TextBlock
+                                    AutomationProperties.AccessibilityView="Raw"
+                                    FontFamily="{ThemeResource SymbolThemeFontFamily}"
+                                    FontSize="16"
+                                    IsTextScaleFactorEnabled="False"
+                                    Text="&#xE89A;" />
                             </InkToolbarCustomToggleButton>
                         </toolkit:WrapPanel>
 
@@ -624,8 +626,7 @@
                                 VerticalAlignment="Center"
                                 FontFamily="{ThemeResource SymbolThemeFontFamily}"
                                 IsTextScaleFactorEnabled="False"
-                                Text="&#xE81C;"
-                                TextLineBounds="Tight" />
+                                Text="&#xE81C;" />
                             <TextBlock
                                 x:Uid="HistoryLabel"
                                 VerticalAlignment="Center"

--- a/CharacterMap/CharacterMap/Views/CollectionManagementView.xaml
+++ b/CharacterMap/CharacterMap/Views/CollectionManagementView.xaml
@@ -89,7 +89,7 @@
                         Style="{StaticResource MapInfoButtonStyle}"
                         ToolTipService.Placement="Bottom"
                         d:Label="Rename">
-                        <FontIcon Glyph="&#xE13E;" />
+                        <FontIcon Glyph="&#xE8AC;" />
                     </controls:UXButton>
                     <controls:UXButton
                         x:Uid="DeleteCollectionButton"
@@ -101,7 +101,7 @@
                         Style="{StaticResource MapInfoButtonStyle}"
                         ToolTipService.Placement="Bottom"
                         d:Label="Delete">
-                        <FontIcon Glyph="&#xE107;" />
+                        <FontIcon Glyph="&#xE74D;" />
                     </controls:UXButton>
                     <controls:UXButton
                         x:Name="CollectionExportButton"
@@ -198,14 +198,14 @@
                                 Click="{x:Bind AllFontsList.ClearSelection}"
                                 IsEnabled="{x:Bind AllFontsList.HasSelection, Mode=OneWay}"
                                 RelativePanel.AlignRightWithPanel="True">
-                                <FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}" Glyph="&#xE1C5;" />
+                                <FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}" Glyph="&#xE8E6;" />
                             </controls:UXButton>
                             <controls:UXButton
                                 x:Uid="AddTooButton"
                                 Click="{x:Bind ViewModel.AddToCollection}"
                                 IsEnabled="{x:Bind core:Converters.TrueFalse(AllFontsList.HasSelection, ViewModel.IsSaving), Mode=OneWay}"
                                 IsLabelVisible="True">
-                                <FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}" Glyph="&#xE109;" />
+                                <FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}" Glyph="&#xE710;" />
                             </controls:UXButton>
                         </StackPanel>
 
@@ -255,13 +255,13 @@
                                 Click="{x:Bind CollectionFontsList.ClearSelection}"
                                 IsEnabled="{x:Bind CollectionFontsList.HasSelection, Mode=OneWay}"
                                 RelativePanel.AlignRightWithPanel="True">
-                                <FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}" Glyph="&#xE1C5;" />
+                                <FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}" Glyph="&#xE8E6;" />
                             </controls:UXButton>
                             <controls:UXButton
                                 x:Uid="RemoveFromButton"
                                 Click="{x:Bind ViewModel.RemoveFromCollection}"
                                 IsEnabled="{x:Bind core:Converters.TrueFalse(CollectionFontsList.HasSelection, ViewModel.IsSaving), Mode=OneWay}">
-                                <FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}" Glyph="&#xE108;" />
+                                <FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}" Glyph="&#xE738;" />
                             </controls:UXButton>
                         </StackPanel>
 

--- a/CharacterMap/CharacterMap/Views/ExportView.xaml
+++ b/CharacterMap/CharacterMap/Views/ExportView.xaml
@@ -590,7 +590,8 @@
                                             VerticalAlignment="Center"
                                             FontFamily="{ThemeResource SymbolThemeFontFamily}"
                                             FontSize="12"
-                                            Text="&#xE019;"
+                                            IsTextScaleFactorEnabled="False"
+                                            Text="&#xE70D;"
                                             TextLineBounds="Tight" />
                                     </StackPanel>
                                 </Button.Content>

--- a/CharacterMap/CharacterMap/Views/FontMapView.xaml
+++ b/CharacterMap/CharacterMap/Views/FontMapView.xaml
@@ -130,11 +130,11 @@
                     x:Name="TogglePaneButton"
                     x:Uid="TogglePaneButton"
                     Grid.Column="4"
-                    Checked="{x:Bind ViewModel.HidePane}"
+                    Checked="{x:Bind ViewModel.ShowPane}"
                     Loaded="PaneButton_Loaded"
-                    Unchecked="{x:Bind ViewModel.ShowPane}">
+                    Unchecked="{x:Bind ViewModel.HidePane}">
                     <AppBarToggleButton.Icon>
-                        <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="&#xE89F;" />
+                        <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="&#xE90D;" />
                     </AppBarToggleButton.Icon>
                 </AppBarToggleButton>
             </Grid>

--- a/CharacterMap/CharacterMap/Views/FontMapView.xaml
+++ b/CharacterMap/CharacterMap/Views/FontMapView.xaml
@@ -89,7 +89,7 @@
                     <FontIcon
                         x:Name="MOIcon"
                         FontFamily="{StaticResource SymbolThemeFontFamily}"
-                        Glyph="&#xE13C;"
+                        Glyph="&#xE8AB;"
                         RenderTransformOrigin="0.5 0.5">
                         <FontIcon.RenderTransform>
                             <CompositeTransform />
@@ -106,14 +106,14 @@
                     x:Uid="IncreaseSizeButton"
                     Grid.Column="1"
                     Click="{x:Bind ViewModel.IncreaseCharacterSize}">
-                    <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="&#xE1C7;" />
+                    <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="&#xE8E8;" />
                 </AppBarButton>
                 <AppBarButton
                     x:Name="DecreaseSizeButton"
                     x:Uid="DecreaseSizeButton"
                     Grid.Column="2"
                     Click="{x:Bind ViewModel.DecreaseCharacterSize}">
-                    <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="&#xE1C6;" />
+                    <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="&#xE8E7;" />
                 </AppBarButton>
                 <AppBarToggleButton
                     x:Name="ToggleCopyPaneButton"
@@ -134,7 +134,7 @@
                     Loaded="PaneButton_Loaded"
                     Unchecked="{x:Bind ViewModel.ShowPane}">
                     <AppBarToggleButton.Icon>
-                        <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="&#xE126;" />
+                        <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="&#xE89F;" />
                     </AppBarToggleButton.Icon>
                 </AppBarToggleButton>
             </Grid>
@@ -248,7 +248,7 @@
                     Tag="Copy"
                     Visibility="{x:Bind core:Converters.FalseToVis(ViewModel.SelectedCharAnalysis.ContainsBitmapGlyphs), Mode=OneWay, FallbackValue=Collapsed}">
                     <MenuFlyoutItem.Icon>
-                        <FontIcon Foreground="Black" Glyph="&#xE002;" />
+                        <FontIcon Foreground="Black" Glyph="&#xE73B;" />
                     </MenuFlyoutItem.Icon>
                 </MenuFlyoutItem>
                 <MenuFlyoutItem
@@ -259,7 +259,7 @@
                     Tag="Copy"
                     Visibility="{x:Bind core:Converters.FalseToVis(ViewModel.SelectedCharAnalysis.ContainsBitmapGlyphs), Mode=OneWay, FallbackValue=Collapsed}">
                     <MenuFlyoutItem.Icon>
-                        <FontIcon Foreground="White" Glyph="&#xE002;" />
+                        <FontIcon Foreground="White" Glyph="&#xE73B;" />
                     </MenuFlyoutItem.Icon>
                 </MenuFlyoutItem>
                 <MenuFlyoutItem
@@ -287,7 +287,7 @@
                     Tag="Copy"
                     Visibility="{x:Bind core:Converters.TrueAndFalseToVis(ViewModel.SelectedCharAnalysis.IsFullVectorBased, ViewModel.IsSvgChar), Mode=OneWay}">
                     <MenuFlyoutItem.Icon>
-                        <FontIcon Foreground="Black" Glyph="&#xE002;" />
+                        <FontIcon Foreground="Black" Glyph="&#xE73B;" />
                     </MenuFlyoutItem.Icon>
                 </MenuFlyoutItem>
                 <MenuFlyoutItem
@@ -298,7 +298,7 @@
                     Tag="Copy"
                     Visibility="{x:Bind core:Converters.TrueAndFalseToVis(ViewModel.SelectedCharAnalysis.IsFullVectorBased, ViewModel.IsSvgChar), Mode=OneWay}">
                     <MenuFlyoutItem.Icon>
-                        <FontIcon Foreground="White" Glyph="&#xE002;" />
+                        <FontIcon Foreground="White" Glyph="&#xE73B;" />
                     </MenuFlyoutItem.Icon>
                 </MenuFlyoutItem>
             </MenuFlyoutSubItem>
@@ -352,7 +352,7 @@
                     CommandParameter="{x:Bind ViewModel.BlackColor}"
                     Style="{StaticResource ThemeMenuFlyoutItemStyle}">
                     <MenuFlyoutItem.Icon>
-                        <FontIcon Foreground="Black" Glyph="&#xE002;" />
+                        <FontIcon Foreground="Black" Glyph="&#xE73B;" />
                     </MenuFlyoutItem.Icon>
                 </MenuFlyoutItem>
                 <MenuFlyoutItem
@@ -361,7 +361,7 @@
                     CommandParameter="{x:Bind ViewModel.WhiteColor}"
                     Style="{StaticResource ThemeMenuFlyoutItemStyle}">
                     <MenuFlyoutItem.Icon>
-                        <FontIcon Foreground="White" Glyph="&#xE002;" />
+                        <FontIcon Foreground="White" Glyph="&#xE73B;" />
                     </MenuFlyoutItem.Icon>
                 </MenuFlyoutItem>
             </MenuFlyoutSubItem>
@@ -385,7 +385,7 @@
                     CommandParameter="{x:Bind ViewModel.BlackColor}"
                     Style="{StaticResource ThemeMenuFlyoutItemStyle}">
                     <MenuFlyoutItem.Icon>
-                        <FontIcon Foreground="Black" Glyph="&#xE002;" />
+                        <FontIcon Foreground="Black" Glyph="&#xE73B;" />
                     </MenuFlyoutItem.Icon>
                 </MenuFlyoutItem>
                 <MenuFlyoutItem
@@ -394,7 +394,7 @@
                     CommandParameter="{x:Bind ViewModel.WhiteColor}"
                     Style="{StaticResource ThemeMenuFlyoutItemStyle}">
                     <MenuFlyoutItem.Icon>
-                        <FontIcon Foreground="White" Glyph="&#xE002;" />
+                        <FontIcon Foreground="White" Glyph="&#xE73B;" />
                     </MenuFlyoutItem.Icon>
                 </MenuFlyoutItem>
             </MenuFlyoutSubItem>
@@ -445,7 +445,7 @@
                     Click="{x:Bind ToggleCompactOverlay}"
                     Foreground="{Binding Foreground, ElementName=TitleBar}"
                     Style="{StaticResource IconToggleButtonStyle}">
-                    <FontIcon FontSize="14" Glyph="&#xE2B4;" />
+                    <FontIcon FontSize="14" Glyph="&#xE8A7;" />
                 </ToggleButton>
             </StackPanel>-->
         </controls:XamlTitleBar>
@@ -546,7 +546,7 @@
                             <ColumnDefinition Width="Auto" />
                             <ColumnDefinition Width="*" />
                         </Grid.ColumnDefinitions>
-                        <FontIcon Glyph="&#xE109;" />
+                        <FontIcon Glyph="&#xE710;" />
                         <TextBlock
                             x:Uid="AddToCollectionHint"
                             Grid.Column="1"
@@ -599,7 +599,7 @@
                         <CompositeTransform />
                     </AutoSuggestBox.RenderTransform>
                     <AutoSuggestBox.QueryIcon>
-                        <FontIcon Glyph="&#xE11A;" />
+                        <FontIcon Glyph="&#xE721;" />
                     </AutoSuggestBox.QueryIcon>
                     <AutoSuggestBox.KeyboardAccelerators>
                         <KeyboardAccelerator
@@ -1046,7 +1046,7 @@
                             Margin="0,0,-2,0"
                             FontFamily="{ThemeResource SymbolThemeFontFamily}"
                             FontSize="18"
-                            Glyph="&#xE13C;"
+                            Glyph="&#xE8AB;"
                             RenderTransformOrigin="0.5 0.5">
                             <FontIcon.RenderTransform>
                                 <CompositeTransform />
@@ -1067,7 +1067,7 @@
                             Margin="0,0,-2,0"
                             FontFamily="{ThemeResource SymbolThemeFontFamily}"
                             FontSize="18"
-                            Glyph="&#xE16E;" />
+                            Glyph="&#xE71C;" />
                         <Button.Flyout>
                             <Flyout
                                 x:Name="CatFlyout"
@@ -1116,7 +1116,7 @@
                         Margin="0,-2,-2,-2"
                         FontFamily="{StaticResource SymbolThemeFontFamily}"
                         FontSize="18"
-                        Glyph="&#xE10C;" />
+                        Glyph="&#xE712;" />
                 </controls:UXButton>
 
 
@@ -1185,7 +1185,7 @@
                                         <FontIcon
                                             FontFamily="{ThemeResource SymbolThemeFontFamily}"
                                             FontSize="13.333"
-                                            Glyph="&#xE13C;" />
+                                            Glyph="&#xE8AB;" />
                                     </Button>
                                 </controls:InfoBar.SecondaryContent>
                             </controls:InfoBar>
@@ -1202,7 +1202,7 @@
                                         <FontIcon
                                             FontFamily="{ThemeResource SymbolThemeFontFamily}"
                                             FontSize="13.333"
-                                            Glyph="&#xE13C;" />
+                                            Glyph="&#xE8AB;" />
                                     </Button>
                                 </controls:InfoBar.SecondaryContent>
                             </controls:InfoBar>
@@ -1585,6 +1585,7 @@
                         FontSize="18"
                         Foreground="{ThemeResource ListViewItemPlaceholderBackgroundThemeBrush}"
                         IsHitTestVisible="False"
+                        IsTextScaleFactorEnabled="False"
                         OpticalMarginAlignment="TrimSideBearings"
                         Text="&#xE784;" />
                 </Grid>
@@ -1880,7 +1881,7 @@
                                     <FontIcon
                                         x:Name="CopyIcon"
                                         FontSize="18"
-                                        Glyph="&#xE16F;"
+                                        Glyph="&#xE8C8;"
                                         RenderTransformOrigin="0.5,0.5">
                                         <FontIcon.RenderTransform>
                                             <CompositeTransform />
@@ -1917,7 +1918,7 @@
                                     </controls:UXButton>-->
 
                                     <controls:UXButton x:Uid="BtnSaveGlyph" d:Label="Save">
-                                        <FontIcon Glyph="&#xE105;" />
+                                        <FontIcon Glyph="&#xE74E;" />
                                         <Button.Flyout>
                                             <MenuFlyout
                                                 x:Name="SaveAsFlyout"
@@ -2197,7 +2198,7 @@
                                                                 <FontIcon
                                                                     FontFamily="{ThemeResource SymbolThemeFontFamily}"
                                                                     FontSize="16"
-                                                                    Glyph="&#xE16F;" />
+                                                                    Glyph="&#xE8C8;" />
                                                             </controls:UXButton>
 
                                                             <!--
@@ -2233,7 +2234,7 @@
                                             <FontIcon
                                                 FontFamily="{ThemeResource SymbolThemeFontFamily}"
                                                 FontSize="16"
-                                                Glyph="&#xE16F;" />
+                                                Glyph="&#xE8C8;" />
                                         </controls:UXButton>
                                     </Grid>
                                 </DataTemplate>

--- a/CharacterMap/CharacterMap/Views/FontMapView.xaml.cs
+++ b/CharacterMap/CharacterMap/Views/FontMapView.xaml.cs
@@ -891,7 +891,7 @@ public sealed partial class FontMapView : ViewBase, IInAppNotificationPresenter,
 
     private void PaneButton_Loaded(object sender, RoutedEventArgs e)
     {
-        ((AppBarToggleButton)sender).IsChecked = !ResourceHelper.AppSettings.EnablePreviewPane;
+        ((AppBarToggleButton)sender).IsChecked = ResourceHelper.AppSettings.EnablePreviewPane;
     }
 
     private void ToggleCopyPaneButton_Loaded(object sender, RoutedEventArgs e)

--- a/CharacterMap/CharacterMap/Views/MainPage.xaml
+++ b/CharacterMap/CharacterMap/Views/MainPage.xaml
@@ -104,7 +104,7 @@
                                     <controls:ButtonLabel
                                         Title="{core:Localizer Key='CompareFontsTitle/Text'}"
                                         Description="{core:Localizer Key='CompareFontsDescription/Text'}"
-                                        Glyph="&#xE1D3;"
+                                        Glyph="&#xE8F1;"
                                         Shortcut="Ctrl+K" />
                                 </Button>
                             </controls:ButtonGroup>
@@ -145,7 +145,7 @@
                                     x:Name="AppMenuSettings"
                                     x:Load="{x:Bind core:Converters.False(ViewModel.IsSecondaryView)}"
                                     Click="BtnSettings_OnClick">
-                                    <controls:ButtonLabel Title="{core:Localizer Key='SettingsHeader/Text'}" Glyph="&#xE115;" />
+                                    <controls:ButtonLabel Title="{core:Localizer Key='SettingsHeader/Text'}" Glyph="&#xE713;" />
                                 </Button>
 
                                 <Button
@@ -201,7 +201,7 @@
                     <FontIcon
                         FontFamily="{StaticResource SymbolThemeFontFamily}"
                         FontSize="14"
-                        Glyph="&#xE1D3;" />
+                        Glyph="&#xE8F1;" />
                 </MenuFlyoutItem.Icon>
             </MenuFlyoutItem>
 
@@ -244,7 +244,7 @@
                     <FontIcon
                         FontFamily="{StaticResource SymbolThemeFontFamily}"
                         FontSize="14"
-                        Glyph="&#xE115;" />
+                        Glyph="&#xE713;" />
                 </MenuFlyoutItem.Icon>
             </MenuFlyoutItem>
 
@@ -357,7 +357,7 @@
                             x:Uid="MenuToggle"
                             core:Properties.ClickAnimation="Text"
                             Click="OpenFontPaneButton_Click"
-                            Content="&#xE169;"
+                            Content="&#xE8C4;"
                             Foreground="{Binding ElementName=TitleButtonsPresenter, Path=Foreground}"
                             Style="{StaticResource TitleBarButtonStyle}"
                             Visibility="Collapsed">
@@ -626,13 +626,13 @@
                                     x:Uid="EditCollectionButton"
                                     Click="RenameFontCollection_Click"
                                     d:Label="Rename">
-                                    <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="&#xE13E;" />
+                                    <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="&#xE8AC;" />
                                 </controls:UXButton>
                                 <controls:UXButton
                                     x:Uid="DeleteCollectionButton"
                                     Click="DeleteCollection_Click"
                                     d:Label="Delete">
-                                    <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="&#xE107;" />
+                                    <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="&#xE74D;" />
                                 </controls:UXButton>
                                 <controls:UXButton
                                     x:Name="CollectionExportButton"
@@ -692,7 +692,7 @@
                                     <FontIcon
                                         FontFamily="{StaticResource SymbolThemeFontFamily}"
                                         FontSize="16"
-                                        Glyph="&#xE1D3;" />
+                                        Glyph="&#xE8F1;" />
                                 </controls:UXButton>
                             </wct:WrapPanel>
                         </Grid>
@@ -844,7 +844,7 @@
                                     VerticalAlignment="Center"
                                     FontFamily="{StaticResource SymbolThemeFontFamily}"
                                     FontSize="14"
-                                    Glyph="&#xE1D3;" />
+                                    Glyph="&#xE8F1;" />
                             </controls:LabelButton.IconContent>
                             <TextBlock
                                 x:Uid="CompareFontsTitle"
@@ -861,7 +861,7 @@
                         <!--<FontIcon
                                 FontFamily="{ThemeResource SymbolThemeFontFamily}"
                                 FontSize="16"
-                                Glyph="&#xE1D3;" />-->
+                                Glyph="&#xE8F1;" />-->
                         <!--
                         </AppBarButton>-->
 
@@ -877,7 +877,7 @@
                             <FontIcon
                                 FontFamily="{ThemeResource SymbolThemeFontFamily}"
                                 FontSize="18"
-                                Glyph="&#xE127;" />
+                                Glyph="&#xE8A0;" />
                         </controls:UXButton>
 
                         <controls:UXButton
@@ -893,7 +893,7 @@
                             <FontIcon
                                 FontFamily="{ThemeResource SymbolThemeFontFamily}"
                                 FontSize="18"
-                                Glyph="&#xE126;" />
+                                Glyph="&#xE89F;" />
                         </controls:UXButton>
 
                     </Grid>
@@ -966,7 +966,7 @@
                                                 Margin="0 2 0 0"
                                                 FontFamily="{ThemeResource SymbolThemeFontFamily}"
                                                 FontSize="12"
-                                                Glyph="&#xE154;" />
+                                                Glyph="&#xE8A9;" />
 
                                             <FontIcon
                                                 x:Name="TypeRampIcon"
@@ -1047,7 +1047,7 @@
                                             VerticalAlignment="Center"
                                             FontFamily="{StaticResource SymbolThemeFontFamily}"
                                             FontSize="16"
-                                            Glyph="&#xE115;" />
+                                            Glyph="&#xE713;" />
                                         <muxc:AnimatedIcon
                                             x:Name="SettingsButtonAnimatedIcon"
                                             x:Load="False"
@@ -1059,7 +1059,7 @@
                                                 <muxc:FontIconSource
                                                     FontFamily="{StaticResource SymbolThemeFontFamily}"
                                                     FontSize="16"
-                                                    Glyph="&#xE115;" />
+                                                    Glyph="&#xE713;" />
                                             </muxc:AnimatedIcon.FallbackIconSource>
                                         </muxc:AnimatedIcon>
                                     </Grid>
@@ -1412,8 +1412,8 @@
                 <VisualState x:Name="WindowState" />
                 <VisualState x:Name="FullscreenState">
                     <VisualState.Setters>
-                        <Setter Target="ToggleFullscreenIcon.Glyph" Value="&#xE1D8;" />
-                        <Setter Target="FullscreenLabel.Glyph" Value="&#xE1D8;" />
+                        <Setter Target="ToggleFullscreenIcon.Glyph" Value="&#xE73F;" />
+                        <Setter Target="FullscreenLabel.Glyph" Value="&#xE73F;" />
                         <Setter Target="FullscreenLabel.Title" Value="{core:Localizer Key='RestoreLabel/Text'}" />
                     </VisualState.Setters>
                 </VisualState>

--- a/CharacterMap/CharacterMap/Views/PrintView.xaml
+++ b/CharacterMap/CharacterMap/Views/PrintView.xaml
@@ -30,7 +30,7 @@
             <Setter Property="HeaderTemplate" Value="{StaticResource DefaultControlHeaderTemplate}" />
         </Style>
 
-      
+
 
     </UserControl.Resources>
 
@@ -78,7 +78,8 @@
                                                 VerticalAlignment="Center"
                                                 FontFamily="{ThemeResource SymbolThemeFontFamily}"
                                                 FontSize="12"
-                                                Text="&#xE019;"
+                                                IsTextScaleFactorEnabled="False"
+                                                Text="&#xE70D;"
                                                 TextLineBounds="Tight" />
                                         </StackPanel>
                                     </Button.Content>

--- a/CharacterMap/CharacterMap/Views/QuickCompareView.xaml
+++ b/CharacterMap/CharacterMap/Views/QuickCompareView.xaml
@@ -416,7 +416,7 @@
                                 FontFamily="{ThemeResource SymbolThemeFontFamily}"
                                 FontSize="12"
                                 Foreground="{ThemeResource AppBarItemForegroundThemeBrush}"
-                                Glyph="&#xE0A6;" />
+                                Glyph="&#xE72B;" />
                         </Button>
                     </controls:XamlTitleBar>
 
@@ -470,6 +470,7 @@
                                     <Run
                                         FontFamily="{ThemeResource SymbolThemeFontFamily}"
                                         FontSize="10"
+                                        IsTextScaleFactorEnabled="False"
                                         Text="&#xE70D;" />
                                 </TextBlock>
 
@@ -542,7 +543,7 @@
                                     x:Uid="LayoutListToggle"
                                     core:Properties.ToolTipStyleKey="DefaultThemeToolTipStyle"
                                     Click="ListView_Click">
-                                    <FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}" Glyph="&#xE14C;" />
+                                    <FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}" Glyph="&#xE8FD;" />
                                 </RadioButton>
                             </muxc:RadioButtons>
 

--- a/CharacterMap/CharacterMap/Views/SettingsView.xaml
+++ b/CharacterMap/CharacterMap/Views/SettingsView.xaml
@@ -149,7 +149,7 @@
                         Content="{x:Bind h:Localization.Get('SettingsExportHeader/Text')}"
                         Tag="ExportPanel">
                         <controls:MenuButton.Icon>
-                            <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="&#xE2B4;" />
+                            <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="&#xE8A7;" />
                         </controls:MenuButton.Icon>
                     </controls:MenuButton>
 
@@ -158,7 +158,7 @@
                         Content="{x:Bind h:Localization.Get('SettingsCharacterSearchHeader/Text')}"
                         Tag="SearchPanel">
                         <controls:MenuButton.Icon>
-                            <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="&#xE11A;" />
+                            <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="&#xE721;" />
                         </controls:MenuButton.Icon>
                     </controls:MenuButton>
 
@@ -850,7 +850,7 @@
                                                     VerticalAlignment="Top"
                                                     FontFamily="{ThemeResource SymbolThemeFontFamily}"
                                                     FontSize="30"
-                                                    Glyph="&#xE1E3;" />
+                                                    Glyph="&#xE7C9;" />
 
                                                 <StackPanel Grid.Column="1">
                                                     <TextBlock

--- a/CharacterMap/CharacterMap/Views/TestView.xaml
+++ b/CharacterMap/CharacterMap/Views/TestView.xaml
@@ -550,7 +550,7 @@
                                 FontFamily="{ThemeResource SymbolThemeFontFamily}"
                                 FontSize="12"
                                 Foreground="{ThemeResource ComboBoxDropDownGlyphForeground}"
-                                Glyph="&#xE0E5;"
+                                Glyph="&#xE70D;"
                                 IsHitTestVisible="False" />-->
 
                             <Popup x:Name="Popup" RequestedTheme="Light">
@@ -1331,8 +1331,9 @@
                                     FontSize="16"
                                     FontWeight="Black"
                                     Foreground="{ThemeResource CheckBoxCheckGlyphForegroundUnchecked}"
+                                    IsTextScaleFactorEnabled="False"
                                     Opacity="0"
-                                    Text="&#xE001;" />
+                                    Text="&#xE73E;" />
                             </Grid>
                             <ContentPresenter
                                 x:Name="ContentPresenter"


### PR DESCRIPTION
- Replace deprecated glyphs
- Disable text enlargement for textblock glyphs
- Change the `TogglePaneButton` glyph and behavior to match the `ToggleCopyPaneButton` one

https://github.com/character-map-uwp/Character-Map-UWP/assets/698155/52dda294-0be9-43dd-b44f-12b96c384f3b

- Partial fix to the `BallpointPen` button animation, still need to improve the press and checked pointerover/press states:

https://github.com/character-map-uwp/Character-Map-UWP/assets/698155/540a5052-f851-44b7-8540-68dcc1a8d291

