### PR TITLE
Fix #391

### DIFF
--- a/CharacterMap/CharacterMap/Core/FontFinder.cs
+++ b/CharacterMap/CharacterMap/Core/FontFinder.cs
@@ -290,11 +290,22 @@ public class FontFinder
             string q;
             if (IsQuery(query, Localization.Get("CharacterFilter"), "char:", out q))
             {
-                foreach (var ch in q)
+                System.Globalization.StringInfo inf = new(q);
+                for (int i = 0; i < inf.LengthInTextElements; i++)
                 {
-                    if (ch == ' ')
+                    var ch = inf.SubstringByTextElements(i);
+                    if (ch == " ")
                         continue;
-                    fontList = BasicFontFilter.ForChar(new(ch)).Query(fontList, fontCollections);
+
+                    Character c = ch.Length switch
+                    {
+                        1 => new((uint)ch[0]),
+                        2 => new((uint)char.ConvertToUtf32(ch[0], ch[1])),
+                        _ => null
+                    };
+                 
+                    if (c is not null)
+                        fontList = BasicFontFilter.ForChar(c).Query(fontList, fontCollections);
                 }
                 filterTitle = $"{filter.FilterTitle} \"{q}\"";
             }


### PR DESCRIPTION
Fix #391  — Correctly handle multi-code-unit characters (surrogate pairs / emoji / other astral-plane glyphs) in the character filter (char:) so searching by a character works reliably and no longer produces incorrect behavior.