### PR TITLE
Add typography support for icon generation

### DIFF
--- a/CharacterMap/CharacterMap/Provider/CSharpDevProvider.cs
+++ b/CharacterMap/CharacterMap/Provider/CSharpDevProvider.cs
@@ -25,20 +25,22 @@ public abstract class CSharpJupiterDevProviderBase : DevProviderBase
 
         string pathIconData = GetOutlineGeometry(c, Options);
 
-        string fontIcon = $"new FontIcon {{ FontFamily = new {Namespace}.UI.Xaml.Media.FontFamily(\"{v?.XamlFontSource}\") , Glyph = \"\\u{hex}\" }};";
+        string fontIcon = $"new FontIcon {{ FontFamily = new {Namespace}.UI.Xaml.Media.FontFamily(\"{v?.XamlFontSource}\"), Glyph = \"\\u{hex}\" }};";
+        bool hasTypography = false;
 
         if (GetTypographyMapping(Options) is { } m)
         {
             string csValue = string.Format(m.CodeValue, Namespace);
             fontIcon =
-                $"var f = new FontIcon {{ FontFamily = new {Namespace}.UI.Xaml.Media.FontFamily(\"{v?.XamlFontSource}\") , Glyph = \"\\u{hex}\" }};\n" +
+                $"var f = new FontIcon {{ FontFamily = new {Namespace}.UI.Xaml.Media.FontFamily(\"{v?.XamlFontSource}\"), Glyph = \"\\u{hex}\" }};\n" +
                 $"{Namespace}.UI.Xaml.Documents.Typography.Set{m.PropertyName}(f, {csValue});";
+            hasTypography = true;
         }
 
         var ops = new List<DevOption>()
         {
             new ("TxtXamlCode/Header", c.UnicodeIndex > 0xFFFF ? $"\\U{c.UnicodeIndex:x8}".ToUpper() : $"\\u{hex}"),
-            new ("TxtFontIcon/Header", fontIcon, supportsTypography: true),
+            new ("TxtFontIcon/Header", fontIcon, forceExtended: hasTypography, supportsTypography: true),
         };
 
         if (!string.IsNullOrWhiteSpace(pathIconData))

--- a/CharacterMap/CharacterMap/Provider/CSharpDevProvider.cs
+++ b/CharacterMap/CharacterMap/Provider/CSharpDevProvider.cs
@@ -25,10 +25,20 @@ public abstract class CSharpJupiterDevProviderBase : DevProviderBase
 
         string pathIconData = GetOutlineGeometry(c, Options);
 
+        string fontIcon = $"new FontIcon {{ FontFamily = new {Namespace}.UI.Xaml.Media.FontFamily(\"{v?.XamlFontSource}\") , Glyph = \"\\u{hex}\" }};";
+
+        if (GetTypographyMapping(Options) is { } m)
+        {
+            string csValue = string.Format(m.CodeValue, Namespace);
+            fontIcon =
+                $"var f = new FontIcon {{ FontFamily = new {Namespace}.UI.Xaml.Media.FontFamily(\"{v?.XamlFontSource}\") , Glyph = \"\\u{hex}\" }};\n" +
+                $"{Namespace}.UI.Xaml.Documents.Typography.Set{m.PropertyName}(f, {csValue});";
+        }
+
         var ops = new List<DevOption>()
         {
             new ("TxtXamlCode/Header", c.UnicodeIndex > 0xFFFF ? $"\\U{c.UnicodeIndex:x8}".ToUpper() : $"\\u{hex}"),
-            new ("TxtFontIcon/Header", $"new FontIcon {{ FontFamily = new {Namespace}.UI.Xaml.Media.FontFamily(\"{v?.XamlFontSource}\") , Glyph = \"\\u{hex}\" }};"),
+            new ("TxtFontIcon/Header", fontIcon, supportsTypography: true),
         };
 
         if (!string.IsNullOrWhiteSpace(pathIconData))

--- a/CharacterMap/CharacterMap/Provider/CppCxDevProvider.cs
+++ b/CharacterMap/CharacterMap/Provider/CppCxDevProvider.cs
@@ -26,10 +26,18 @@ public class CppCxDevProvider : DevProviderBase
             $"f->FontFamily = ref new Media::FontFamily(L\"{v?.XamlFontSource}\");\n" +
             $"f->Glyph = L\"\\u{hex}\";";
 
+        if (GetTypographyMapping(Options) is { } m)
+        {
+            string cppValue = m.CodeValue.Contains("{0}")
+                ? string.Format(m.CodeValue, "Windows").Replace(".", "::")
+                : m.CodeValue;
+            fontIcon += $"\nWindows::UI::Xaml::Documents::Typography::Set{m.PropertyName}(f, {cppValue});";
+        }
+
         var ops = new List<DevOption>()
         {
             new ("TxtXamlCode/Header", c.UnicodeIndex > 0xFFFF ? $"\\U{c.UnicodeIndex:x8}".ToUpper() : $"\\u{hex}"),
-            new ("TxtFontIcon/Header", fontIcon, true),
+            new ("TxtFontIcon/Header", fontIcon, forceExtended: true, supportsTypography: true),
         };
 
         if (!string.IsNullOrWhiteSpace(pathIconData))

--- a/CharacterMap/CharacterMap/Provider/CppWinrtDevProvider.cs
+++ b/CharacterMap/CharacterMap/Provider/CppWinrtDevProvider.cs
@@ -30,10 +30,20 @@ public abstract class CppWinrtJupiterDevProviderBase : DevProviderBase
             $"f.Glyph(L\"\\u{hex}\");\n" +
             $"f.FontFamily(Media::FontFamily(L\"{v?.XamlFontSource}\"));";
 
+        if (GetTypographyMapping(Options) is { } m)
+        {
+            string cppValue = m.CodeValue.Contains("{0}")
+                ? string.Format(m.CodeValue, Namespace).Replace(".", "::")
+                : m.CodeValue;
+            fontIcon +=
+                $"\n// Add \"#include <winrt/{Namespace}.UI.Xaml.Documents.h>\" to pch.h\n" +
+                $"{Namespace}::UI::Xaml::Documents::Typography::Set{m.PropertyName}(f, {cppValue});";
+        }
+
         var ops = new List<DevOption>()
         {
             new ("TxtXamlCode/Header", c.UnicodeIndex > 0xFFFF ? $"\\U{c.UnicodeIndex:x8}".ToUpper() : $"\\u{hex}"),
-            new ("TxtFontIcon/Header", fontIcon, true),
+            new ("TxtFontIcon/Header", fontIcon, forceExtended: true, supportsTypography: true),
         };
 
         if (!string.IsNullOrWhiteSpace(pathIconData))

--- a/CharacterMap/CharacterMap/Provider/DevProviderBase.cs
+++ b/CharacterMap/CharacterMap/Provider/DevProviderBase.cs
@@ -1,4 +1,6 @@
-﻿namespace CharacterMap.Provider;
+﻿using Microsoft.Graphics.Canvas.Text;
+
+namespace CharacterMap.Provider;
 
 public partial class DevProviderBase
 {
@@ -142,4 +144,128 @@ public abstract partial class DevProviderBase
     /// </summary>
     /// <returns></returns>
     public IReadOnlyList<DevOption> GetOptions() => _previewPaneOptions ??= OnGetOptions();
+
+    /// <summary>
+    /// Maps a typography feature to its property name and platform-specific values.
+    /// </summary>
+    /// <param name="PropertyName">A typography property name.</param>
+    /// <param name="XamlValue">A XAML property value.</param>
+    /// <param name="CodeValue">A code value as it appears in C# code.
+    /// Use {0} as a namespace placeholder for enum types.</param>
+    protected record TypographyMapping(string PropertyName, string XamlValue, string CodeValue);
+
+    /// <summary>
+    /// Gets a typography mapping for the specified character rendering options.
+    /// </summary>
+    /// <param name="options">The character rendering options that specify the
+    /// typography feature to map.</param>
+    /// <returns>
+    /// A <see cref="TypographyMapping"/> instance for the specified character
+    /// rendering options, or null if no mapping is available.
+    /// </returns>
+    protected static TypographyMapping GetTypographyMapping(CharacterRenderingOptions options)
+    {
+        var typo = options.DefaultTypography;
+        if (typo is null)
+            return null;
+
+        return typo.Feature switch
+        {
+            // Stylistic Sets (bool)
+            CanvasTypographyFeatureName.StylisticSet1  => new("StylisticSet1",  "True", "true"),
+            CanvasTypographyFeatureName.StylisticSet2  => new("StylisticSet2",  "True", "true"),
+            CanvasTypographyFeatureName.StylisticSet3  => new("StylisticSet3",  "True", "true"),
+            CanvasTypographyFeatureName.StylisticSet4  => new("StylisticSet4",  "True", "true"),
+            CanvasTypographyFeatureName.StylisticSet5  => new("StylisticSet5",  "True", "true"),
+            CanvasTypographyFeatureName.StylisticSet6  => new("StylisticSet6",  "True", "true"),
+            CanvasTypographyFeatureName.StylisticSet7  => new("StylisticSet7",  "True", "true"),
+            CanvasTypographyFeatureName.StylisticSet8  => new("StylisticSet8",  "True", "true"),
+            CanvasTypographyFeatureName.StylisticSet9  => new("StylisticSet9",  "True", "true"),
+            CanvasTypographyFeatureName.StylisticSet10 => new("StylisticSet10", "True", "true"),
+            CanvasTypographyFeatureName.StylisticSet11 => new("StylisticSet11", "True", "true"),
+            CanvasTypographyFeatureName.StylisticSet12 => new("StylisticSet12", "True", "true"),
+            CanvasTypographyFeatureName.StylisticSet13 => new("StylisticSet13", "True", "true"),
+            CanvasTypographyFeatureName.StylisticSet14 => new("StylisticSet14", "True", "true"),
+            CanvasTypographyFeatureName.StylisticSet15 => new("StylisticSet15", "True", "true"),
+            CanvasTypographyFeatureName.StylisticSet16 => new("StylisticSet16", "True", "true"),
+            CanvasTypographyFeatureName.StylisticSet17 => new("StylisticSet17", "True", "true"),
+            CanvasTypographyFeatureName.StylisticSet18 => new("StylisticSet18", "True", "true"),
+            CanvasTypographyFeatureName.StylisticSet19 => new("StylisticSet19", "True", "true"),
+            CanvasTypographyFeatureName.StylisticSet20 => new("StylisticSet20", "True", "true"),
+
+            // Capitals (FontCapitals)
+            CanvasTypographyFeatureName.SmallCapitalsFromCapitals  => new("Capitals", "AllSmallCaps",  "{0}.UI.Xaml.FontCapitals.AllSmallCaps"),
+            CanvasTypographyFeatureName.SmallCapitals              => new("Capitals", "SmallCaps",     "{0}.UI.Xaml.FontCapitals.SmallCaps"),
+            CanvasTypographyFeatureName.PetiteCapitalsFromCapitals => new("Capitals", "AllPetiteCaps", "{0}.UI.Xaml.FontCapitals.AllPetiteCaps"),
+            CanvasTypographyFeatureName.PetiteCapitals             => new("Capitals", "PetiteCaps",    "{0}.UI.Xaml.FontCapitals.PetiteCaps"),
+            CanvasTypographyFeatureName.Unicase                    => new("Capitals", "Unicase",       "{0}.UI.Xaml.FontCapitals.Unicase"),
+            CanvasTypographyFeatureName.Titling                    => new("Capitals", "Titling",       "{0}.UI.Xaml.FontCapitals.Titling"),
+
+            // Numeral Style (FontNumeralStyle)
+            CanvasTypographyFeatureName.LiningFigures   => new("NumeralStyle", "Lining",   "{0}.UI.Xaml.FontNumeralStyle.Lining"),
+            CanvasTypographyFeatureName.OldStyleFigures => new("NumeralStyle", "OldStyle", "{0}.UI.Xaml.FontNumeralStyle.OldStyle"),
+
+            // Numeral Alignment (FontNumeralAlignment)
+            CanvasTypographyFeatureName.ProportionalFigures => new("NumeralAlignment", "Proportional", "{0}.UI.Xaml.FontNumeralAlignment.Proportional"),
+            CanvasTypographyFeatureName.TabularFigures      => new("NumeralAlignment", "Tabular",      "{0}.UI.Xaml.FontNumeralAlignment.Tabular"),
+
+            // Variants (FontVariants)
+            CanvasTypographyFeatureName.Superscript         => new("Variants", "Superscript","{0}.UI.Xaml.FontVariants.Superscript"),
+            CanvasTypographyFeatureName.Subscript           => new("Variants", "Subscript",  "{0}.UI.Xaml.FontVariants.Subscript"),
+            CanvasTypographyFeatureName.Ordinals            => new("Variants", "Ordinal",    "{0}.UI.Xaml.FontVariants.Ordinal"),
+            CanvasTypographyFeatureName.ScientificInferiors => new("Variants", "Inferior",   "{0}.UI.Xaml.FontVariants.Inferior"),
+            CanvasTypographyFeatureName.RubyNotationForms   => new("Variants", "Ruby",       "{0}.UI.Xaml.FontVariants.Ruby"),
+
+            // Fraction (FontFraction)
+            CanvasTypographyFeatureName.Fractions => new("Fraction", "Slashed", "{0}.UI.Xaml.FontFraction.Slashed"),
+
+            // Swashes (int)
+            CanvasTypographyFeatureName.Swash           => new("StandardSwashes",   "1", "1"),
+            CanvasTypographyFeatureName.ContextualSwash => new("ContextualSwashes", "1", "1"),
+
+            // Alternates (int)
+            CanvasTypographyFeatureName.StylisticAlternates => new("StylisticAlternates", "1", "1"),
+            // Alternates (bool)
+            CanvasTypographyFeatureName.ContextualAlternates => new("ContextualAlternates", "True", "true"),
+
+            // Forms (int)
+            CanvasTypographyFeatureName.AlternateAnnotationForms => new("AnnotationAlternates", "1", "1"),
+            // Forms (bool)
+            CanvasTypographyFeatureName.CaseSensitiveForms => new("CaseSensitiveForms",   "True", "true"),
+            CanvasTypographyFeatureName.HistoricalForms    => new("HistoricalForms",      "True", "true"),
+            CanvasTypographyFeatureName.ExpertForms        => new("EastAsianExpertForms", "True", "true"),
+
+            // East Asian Forms (FontEastAsianLanguage)
+            CanvasTypographyFeatureName.HojoKanjiForms       => new("EastAsianLanguage", "HojoKanji",        "{0}.UI.Xaml.FontEastAsianLanguage.HojoKanji"),
+            CanvasTypographyFeatureName.Jis04Forms           => new("EastAsianLanguage", "Jis04",            "{0}.UI.Xaml.FontEastAsianLanguage.Jis04"),
+            CanvasTypographyFeatureName.Jis78Forms           => new("EastAsianLanguage", "Jis78",            "{0}.UI.Xaml.FontEastAsianLanguage.Jis78"),
+            CanvasTypographyFeatureName.Jis83Forms           => new("EastAsianLanguage", "Jis83",            "{0}.UI.Xaml.FontEastAsianLanguage.Jis83"),
+            CanvasTypographyFeatureName.Jis90Forms           => new("EastAsianLanguage", "Jis90",            "{0}.UI.Xaml.FontEastAsianLanguage.Jis90"),
+            CanvasTypographyFeatureName.NlcKanjiForms        => new("EastAsianLanguage", "NlcKanji",         "{0}.UI.Xaml.FontEastAsianLanguage.NlcKanji"),
+            CanvasTypographyFeatureName.SimplifiedForms      => new("EastAsianLanguage", "Simplified",       "{0}.UI.Xaml.FontEastAsianLanguage.Simplified"),
+            CanvasTypographyFeatureName.TraditionalForms     => new("EastAsianLanguage", "Traditional",      "{0}.UI.Xaml.FontEastAsianLanguage.Traditional"),
+            CanvasTypographyFeatureName.TraditionalNameForms => new("EastAsianLanguage", "TraditionalNames", "{0}.UI.Xaml.FontEastAsianLanguage.TraditionalNames"),
+
+            //// East Asian Widths (FontEastAsianWidths)
+            CanvasTypographyFeatureName.FullWidth          => new("EastAsianWidths", "Full",         "{0}.UI.Xaml.FontEastAsianWidths.Full"),
+            CanvasTypographyFeatureName.HalfWidth          => new("EastAsianWidths", "Half",         "{0}.UI.Xaml.FontEastAsianWidths.Half"),
+            CanvasTypographyFeatureName.ProportionalWidths => new("EastAsianWidths", "Proportional", "{0}.UI.Xaml.FontEastAsianWidths.Proportional"),
+            CanvasTypographyFeatureName.QuarterWidths      => new("EastAsianWidths", "Quarter",      "{0}.UI.Xaml.FontEastAsianWidths.Quarter"),
+            CanvasTypographyFeatureName.ThirdWidths        => new("EastAsianWidths", "Third",        "{0}.UI.Xaml.FontEastAsianWidths.Third"),
+
+            // Ligatures (bool)
+            CanvasTypographyFeatureName.StandardLigatures      => new("StandardLigatures",      "True", "true"),
+            CanvasTypographyFeatureName.ContextualLigatures    => new("ContextualLigatures",    "True", "true"),
+            CanvasTypographyFeatureName.HistoricalLigatures    => new("HistoricalLigatures",    "True", "true"),
+            CanvasTypographyFeatureName.DiscretionaryLigatures => new("DiscretionaryLigatures", "True", "true"),
+
+            // Other (bool)
+            CanvasTypographyFeatureName.CapitalSpacing     => new("CapitalSpacing",       "True", "true"),
+            CanvasTypographyFeatureName.Kerning            => new("Kerning",              "True", "true"),
+            CanvasTypographyFeatureName.MathematicalGreek  => new("MathematicalGreek",    "True", "true"),
+            CanvasTypographyFeatureName.SlashedZero        => new("SlashedZero",          "True", "true"),
+
+            _ => null
+        };
+    }
 }

--- a/CharacterMap/CharacterMap/Provider/VBDevProvider.cs
+++ b/CharacterMap/CharacterMap/Provider/VBDevProvider.cs
@@ -25,10 +25,24 @@ public class VBDevProvider : DevProviderBase
         string pathIconData = GetOutlineGeometry(c, Options);
         string glyph = c.UnicodeIndex > 0xFFFF ? $"ChrW(&H{$"{c.UnicodeIndex:x8}".ToUpper()})" : $"ChrW(&H{hex})";
 
+        string fontIcon = $"New FontIcon With {{ .FontFamily = New Windows.UI.Xaml.Media.FontFamily(\"{v?.XamlFontSource}\"), .Glyph = {glyph} }}";
+        bool hasTypography = false;
+
+        if (GetTypographyMapping(Options) is { } m)
+        {
+            string vbValue = m.CodeValue.Contains("{0}")
+                ? string.Format(m.CodeValue, "Windows")
+                : (m.CodeValue.Equals("true", StringComparison.OrdinalIgnoreCase) ? "True" : m.CodeValue);
+            fontIcon =
+                $"Dim f As New FontIcon With {{ .FontFamily = New Windows.UI.Xaml.Media.FontFamily(\"{v?.XamlFontSource}\"), .Glyph = {glyph} }}\n" +
+                $"Windows.UI.Xaml.Documents.Typography.Set{m.PropertyName}(f, {vbValue})";
+            hasTypography = true;
+        }
+
         var ops = new List<DevOption>()
         {
             new ("TxtXamlCode/Header", glyph),
-            new ("TxtFontIcon/Header", $"New FontIcon With {{ .FontFamily = New Windows.UI.Xaml.Media.FontFamily(\"{v?.XamlFontSource}\"), .Glyph = {glyph} }}"),
+            new ("TxtFontIcon/Header", fontIcon, forceExtended: hasTypography, supportsTypography: true),
         };
 
         if (!string.IsNullOrWhiteSpace(pathIconData))

--- a/CharacterMap/CharacterMap/Provider/XamlDevProvider.cs
+++ b/CharacterMap/CharacterMap/Provider/XamlDevProvider.cs
@@ -1,4 +1,5 @@
-﻿using Windows.UI.Xaml.Controls;
+﻿using Microsoft.Graphics.Canvas.Text;
+using Windows.UI.Xaml.Controls;
 
 namespace CharacterMap.Provider
 {
@@ -23,10 +24,12 @@ namespace CharacterMap.Provider
 
             string pathIconData = GetOutlineGeometry(c, Options);
 
+            string typographyAttributes = GetTypographyAttributes(Options);
+
             var ops = new List<DevOption>()
             {
                 new ("TxtXamlCode/Header", $"&#x{hex};"),
-                new ("TxtFontIcon/Header", $@"<FontIcon FontFamily=""{GetFontSource(v?.XamlFontSource)}"" Glyph=""&#x{hex};"" />", supportsTypography: true),
+                new ("TxtFontIcon/Header", $@"<FontIcon FontFamily=""{GetFontSource(v?.XamlFontSource)}"" Glyph=""&#x{hex};""{typographyAttributes} />", supportsTypography: true),
             };
 
             if (!string.IsNullOrWhiteSpace(pathIconData))
@@ -43,6 +46,112 @@ namespace CharacterMap.Provider
             if (fontSource == "Segoe MDL2 Assets")
                 return "{ThemeResource SymbolThemeFontFamily}";
             return fontSource;
+        }
+
+        private static string GetTypographyAttributes(CharacterRenderingOptions options)
+        {
+            var typo = options.DefaultTypography;
+            if (typo is null)
+                return string.Empty;
+
+            var f = typo.Feature;
+
+            return f switch
+            {
+                // Stylistic Sets
+                CanvasTypographyFeatureName.StylisticSet1 => " Typography.StylisticSet1=\"True\"",
+                CanvasTypographyFeatureName.StylisticSet2 => " Typography.StylisticSet2=\"True\"",
+                CanvasTypographyFeatureName.StylisticSet3 => " Typography.StylisticSet3=\"True\"",
+                CanvasTypographyFeatureName.StylisticSet4 => " Typography.StylisticSet4=\"True\"",
+                CanvasTypographyFeatureName.StylisticSet5 => " Typography.StylisticSet5=\"True\"",
+                CanvasTypographyFeatureName.StylisticSet6 => " Typography.StylisticSet6=\"True\"",
+                CanvasTypographyFeatureName.StylisticSet7 => " Typography.StylisticSet7=\"True\"",
+                CanvasTypographyFeatureName.StylisticSet8 => " Typography.StylisticSet8=\"True\"",
+                CanvasTypographyFeatureName.StylisticSet9 => " Typography.StylisticSet9=\"True\"",
+                CanvasTypographyFeatureName.StylisticSet10 => " Typography.StylisticSet10=\"True\"",
+                CanvasTypographyFeatureName.StylisticSet11 => " Typography.StylisticSet11=\"True\"",
+                CanvasTypographyFeatureName.StylisticSet12 => " Typography.StylisticSet12=\"True\"",
+                CanvasTypographyFeatureName.StylisticSet13 => " Typography.StylisticSet13=\"True\"",
+                CanvasTypographyFeatureName.StylisticSet14 => " Typography.StylisticSet14=\"True\"",
+                CanvasTypographyFeatureName.StylisticSet15 => " Typography.StylisticSet15=\"True\"",
+                CanvasTypographyFeatureName.StylisticSet16 => " Typography.StylisticSet16=\"True\"",
+                CanvasTypographyFeatureName.StylisticSet17 => " Typography.StylisticSet17=\"True\"",
+                CanvasTypographyFeatureName.StylisticSet18 => " Typography.StylisticSet18=\"True\"",
+                CanvasTypographyFeatureName.StylisticSet19 => " Typography.StylisticSet19=\"True\"",
+                CanvasTypographyFeatureName.StylisticSet20 => " Typography.StylisticSet20=\"True\"",
+
+                // Capitals
+                CanvasTypographyFeatureName.SmallCapitalsFromCapitals => " Typography.Capitals=\"AllSmallCaps\"",
+                CanvasTypographyFeatureName.SmallCapitals => " Typography.Capitals=\"SmallCaps\"",
+                CanvasTypographyFeatureName.PetiteCapitalsFromCapitals => " Typography.Capitals=\"AllPetiteCaps\"",
+                CanvasTypographyFeatureName.PetiteCapitals => " Typography.Capitals=\"PetiteCaps\"",
+                CanvasTypographyFeatureName.Unicase => " Typography.Capitals=\"Unicase\"",
+                CanvasTypographyFeatureName.Titling => " Typography.Capitals=\"Titling\"",
+
+                // Numeral Style
+                CanvasTypographyFeatureName.LiningFigures => " Typography.NumeralStyle=\"Lining\"",
+                CanvasTypographyFeatureName.OldStyleFigures => " Typography.NumeralStyle=\"OldStyle\"",
+
+                // Numeral Alignment
+                CanvasTypographyFeatureName.ProportionalFigures => " Typography.NumeralAlignment=\"Proportional\"",
+                CanvasTypographyFeatureName.TabularFigures => " Typography.NumeralAlignment=\"Tabular\"",
+
+                // Variants
+                CanvasTypographyFeatureName.Superscript => " Typography.Variants=\"Superscript\"",
+                CanvasTypographyFeatureName.Subscript => " Typography.Variants=\"Subscript\"",
+                CanvasTypographyFeatureName.Ordinals => " Typography.Variants=\"Ordinal\"",
+                CanvasTypographyFeatureName.ScientificInferiors => " Typography.Variants=\"Inferior\"",
+                CanvasTypographyFeatureName.RubyNotationForms => " Typography.Variants=\"Ruby\"",
+
+                // Fraction
+                CanvasTypographyFeatureName.Fractions => " Typography.Fraction=\"Slashed\"",
+
+                // Swashes
+                CanvasTypographyFeatureName.Swash => " Typography.StandardSwashes=\"1\"",
+                CanvasTypographyFeatureName.ContextualSwash => " Typography.ContextualSwashes=\"1\"",
+
+                // Alternates
+                CanvasTypographyFeatureName.StylisticAlternates => " Typography.StylisticAlternates=\"1\"",
+                CanvasTypographyFeatureName.ContextualAlternates => " Typography.ContextualAlternates=\"True\"",
+
+                // Forms
+                CanvasTypographyFeatureName.AlternateAnnotationForms => " Typography.AnnotationAlternates=\"1\"",
+                CanvasTypographyFeatureName.CaseSensitiveForms => " Typography.CaseSensitiveForms=\"True\"",
+                CanvasTypographyFeatureName.HistoricalForms => " Typography.HistoricalForms=\"True\"",
+                CanvasTypographyFeatureName.ExpertForms => " Typography.EastAsianExpertForms=\"True\"",
+
+                // East Asian Forms
+                CanvasTypographyFeatureName.HojoKanjiForms => " Typography.EastAsianLanguage=\"HojoKanji\"",
+                CanvasTypographyFeatureName.Jis04Forms => " Typography.EastAsianLanguage=\"Jis04\"",
+                CanvasTypographyFeatureName.Jis78Forms => " Typography.EastAsianLanguage=\"Jis78\"",
+                CanvasTypographyFeatureName.Jis83Forms => " Typography.EastAsianLanguage=\"Jis83\"",
+                CanvasTypographyFeatureName.Jis90Forms => " Typography.EastAsianLanguage=\"Jis90\"",
+                CanvasTypographyFeatureName.NlcKanjiForms => " Typography.EastAsianLanguage=\"NlcKanji\"",
+                CanvasTypographyFeatureName.SimplifiedForms => " Typography.EastAsianLanguage=\"Simplified\"",
+                CanvasTypographyFeatureName.TraditionalForms => " Typography.EastAsianLanguage=\"Traditional\"",
+                CanvasTypographyFeatureName.TraditionalNameForms => " Typography.EastAsianLanguage=\"TraditionalNames\"",
+
+                // East Asian Widths
+                CanvasTypographyFeatureName.FullWidth => " Typography.EastAsianWidths=\"Full\"",
+                CanvasTypographyFeatureName.HalfWidth => " Typography.EastAsianWidths=\"Half\"",
+                CanvasTypographyFeatureName.ProportionalWidths => " Typography.EastAsianWidths=\"Proportional\"",
+                CanvasTypographyFeatureName.QuarterWidths => " Typography.EastAsianWidths=\"Quarter\"",
+                CanvasTypographyFeatureName.ThirdWidths => " Typography.EastAsianWidths=\"Third\"",
+
+                // Ligatures
+                CanvasTypographyFeatureName.StandardLigatures => " Typography.StandardLigatures=\"True\"",
+                CanvasTypographyFeatureName.ContextualLigatures => " Typography.ContextualLigatures=\"True\"",
+                CanvasTypographyFeatureName.DiscretionaryLigatures => " Typography.DiscretionaryLigatures=\"True\"",
+                CanvasTypographyFeatureName.HistoricalLigatures => " Typography.HistoricalLigatures=\"True\"",
+
+                // Other
+                CanvasTypographyFeatureName.CapitalSpacing => " Typography.CapitalSpacing=\"True\"",
+                CanvasTypographyFeatureName.Kerning => " Typography.Kerning=\"True\"",
+                CanvasTypographyFeatureName.MathematicalGreek => " Typography.MathematicalGreek=\"True\"",
+                CanvasTypographyFeatureName.SlashedZero => " Typography.SlashedZero=\"True\"",
+
+                _ => string.Empty
+            };
         }
     }
 }

--- a/CharacterMap/CharacterMap/Provider/XamlDevProvider.cs
+++ b/CharacterMap/CharacterMap/Provider/XamlDevProvider.cs
@@ -1,5 +1,4 @@
-﻿using Microsoft.Graphics.Canvas.Text;
-using Windows.UI.Xaml.Controls;
+﻿using Windows.UI.Xaml.Controls;
 
 namespace CharacterMap.Provider
 {
@@ -24,7 +23,9 @@ namespace CharacterMap.Provider
 
             string pathIconData = GetOutlineGeometry(c, Options);
 
-            string typographyAttributes = GetTypographyAttributes(Options);
+            string typographyAttributes = GetTypographyMapping(Options) is { } m
+                ? $" Typography.{m.PropertyName}=\"{m.XamlValue}\""
+                : string.Empty;
 
             var ops = new List<DevOption>()
             {
@@ -46,112 +47,6 @@ namespace CharacterMap.Provider
             if (fontSource == "Segoe MDL2 Assets")
                 return "{ThemeResource SymbolThemeFontFamily}";
             return fontSource;
-        }
-
-        private static string GetTypographyAttributes(CharacterRenderingOptions options)
-        {
-            var typo = options.DefaultTypography;
-            if (typo is null)
-                return string.Empty;
-
-            var f = typo.Feature;
-
-            return f switch
-            {
-                // Stylistic Sets
-                CanvasTypographyFeatureName.StylisticSet1 => " Typography.StylisticSet1=\"True\"",
-                CanvasTypographyFeatureName.StylisticSet2 => " Typography.StylisticSet2=\"True\"",
-                CanvasTypographyFeatureName.StylisticSet3 => " Typography.StylisticSet3=\"True\"",
-                CanvasTypographyFeatureName.StylisticSet4 => " Typography.StylisticSet4=\"True\"",
-                CanvasTypographyFeatureName.StylisticSet5 => " Typography.StylisticSet5=\"True\"",
-                CanvasTypographyFeatureName.StylisticSet6 => " Typography.StylisticSet6=\"True\"",
-                CanvasTypographyFeatureName.StylisticSet7 => " Typography.StylisticSet7=\"True\"",
-                CanvasTypographyFeatureName.StylisticSet8 => " Typography.StylisticSet8=\"True\"",
-                CanvasTypographyFeatureName.StylisticSet9 => " Typography.StylisticSet9=\"True\"",
-                CanvasTypographyFeatureName.StylisticSet10 => " Typography.StylisticSet10=\"True\"",
-                CanvasTypographyFeatureName.StylisticSet11 => " Typography.StylisticSet11=\"True\"",
-                CanvasTypographyFeatureName.StylisticSet12 => " Typography.StylisticSet12=\"True\"",
-                CanvasTypographyFeatureName.StylisticSet13 => " Typography.StylisticSet13=\"True\"",
-                CanvasTypographyFeatureName.StylisticSet14 => " Typography.StylisticSet14=\"True\"",
-                CanvasTypographyFeatureName.StylisticSet15 => " Typography.StylisticSet15=\"True\"",
-                CanvasTypographyFeatureName.StylisticSet16 => " Typography.StylisticSet16=\"True\"",
-                CanvasTypographyFeatureName.StylisticSet17 => " Typography.StylisticSet17=\"True\"",
-                CanvasTypographyFeatureName.StylisticSet18 => " Typography.StylisticSet18=\"True\"",
-                CanvasTypographyFeatureName.StylisticSet19 => " Typography.StylisticSet19=\"True\"",
-                CanvasTypographyFeatureName.StylisticSet20 => " Typography.StylisticSet20=\"True\"",
-
-                // Capitals
-                CanvasTypographyFeatureName.SmallCapitalsFromCapitals => " Typography.Capitals=\"AllSmallCaps\"",
-                CanvasTypographyFeatureName.SmallCapitals => " Typography.Capitals=\"SmallCaps\"",
-                CanvasTypographyFeatureName.PetiteCapitalsFromCapitals => " Typography.Capitals=\"AllPetiteCaps\"",
-                CanvasTypographyFeatureName.PetiteCapitals => " Typography.Capitals=\"PetiteCaps\"",
-                CanvasTypographyFeatureName.Unicase => " Typography.Capitals=\"Unicase\"",
-                CanvasTypographyFeatureName.Titling => " Typography.Capitals=\"Titling\"",
-
-                // Numeral Style
-                CanvasTypographyFeatureName.LiningFigures => " Typography.NumeralStyle=\"Lining\"",
-                CanvasTypographyFeatureName.OldStyleFigures => " Typography.NumeralStyle=\"OldStyle\"",
-
-                // Numeral Alignment
-                CanvasTypographyFeatureName.ProportionalFigures => " Typography.NumeralAlignment=\"Proportional\"",
-                CanvasTypographyFeatureName.TabularFigures => " Typography.NumeralAlignment=\"Tabular\"",
-
-                // Variants
-                CanvasTypographyFeatureName.Superscript => " Typography.Variants=\"Superscript\"",
-                CanvasTypographyFeatureName.Subscript => " Typography.Variants=\"Subscript\"",
-                CanvasTypographyFeatureName.Ordinals => " Typography.Variants=\"Ordinal\"",
-                CanvasTypographyFeatureName.ScientificInferiors => " Typography.Variants=\"Inferior\"",
-                CanvasTypographyFeatureName.RubyNotationForms => " Typography.Variants=\"Ruby\"",
-
-                // Fraction
-                CanvasTypographyFeatureName.Fractions => " Typography.Fraction=\"Slashed\"",
-
-                // Swashes
-                CanvasTypographyFeatureName.Swash => " Typography.StandardSwashes=\"1\"",
-                CanvasTypographyFeatureName.ContextualSwash => " Typography.ContextualSwashes=\"1\"",
-
-                // Alternates
-                CanvasTypographyFeatureName.StylisticAlternates => " Typography.StylisticAlternates=\"1\"",
-                CanvasTypographyFeatureName.ContextualAlternates => " Typography.ContextualAlternates=\"True\"",
-
-                // Forms
-                CanvasTypographyFeatureName.AlternateAnnotationForms => " Typography.AnnotationAlternates=\"1\"",
-                CanvasTypographyFeatureName.CaseSensitiveForms => " Typography.CaseSensitiveForms=\"True\"",
-                CanvasTypographyFeatureName.HistoricalForms => " Typography.HistoricalForms=\"True\"",
-                CanvasTypographyFeatureName.ExpertForms => " Typography.EastAsianExpertForms=\"True\"",
-
-                // East Asian Forms
-                CanvasTypographyFeatureName.HojoKanjiForms => " Typography.EastAsianLanguage=\"HojoKanji\"",
-                CanvasTypographyFeatureName.Jis04Forms => " Typography.EastAsianLanguage=\"Jis04\"",
-                CanvasTypographyFeatureName.Jis78Forms => " Typography.EastAsianLanguage=\"Jis78\"",
-                CanvasTypographyFeatureName.Jis83Forms => " Typography.EastAsianLanguage=\"Jis83\"",
-                CanvasTypographyFeatureName.Jis90Forms => " Typography.EastAsianLanguage=\"Jis90\"",
-                CanvasTypographyFeatureName.NlcKanjiForms => " Typography.EastAsianLanguage=\"NlcKanji\"",
-                CanvasTypographyFeatureName.SimplifiedForms => " Typography.EastAsianLanguage=\"Simplified\"",
-                CanvasTypographyFeatureName.TraditionalForms => " Typography.EastAsianLanguage=\"Traditional\"",
-                CanvasTypographyFeatureName.TraditionalNameForms => " Typography.EastAsianLanguage=\"TraditionalNames\"",
-
-                // East Asian Widths
-                CanvasTypographyFeatureName.FullWidth => " Typography.EastAsianWidths=\"Full\"",
-                CanvasTypographyFeatureName.HalfWidth => " Typography.EastAsianWidths=\"Half\"",
-                CanvasTypographyFeatureName.ProportionalWidths => " Typography.EastAsianWidths=\"Proportional\"",
-                CanvasTypographyFeatureName.QuarterWidths => " Typography.EastAsianWidths=\"Quarter\"",
-                CanvasTypographyFeatureName.ThirdWidths => " Typography.EastAsianWidths=\"Third\"",
-
-                // Ligatures
-                CanvasTypographyFeatureName.StandardLigatures => " Typography.StandardLigatures=\"True\"",
-                CanvasTypographyFeatureName.ContextualLigatures => " Typography.ContextualLigatures=\"True\"",
-                CanvasTypographyFeatureName.DiscretionaryLigatures => " Typography.DiscretionaryLigatures=\"True\"",
-                CanvasTypographyFeatureName.HistoricalLigatures => " Typography.HistoricalLigatures=\"True\"",
-
-                // Other
-                CanvasTypographyFeatureName.CapitalSpacing => " Typography.CapitalSpacing=\"True\"",
-                CanvasTypographyFeatureName.Kerning => " Typography.Kerning=\"True\"",
-                CanvasTypographyFeatureName.MathematicalGreek => " Typography.MathematicalGreek=\"True\"",
-                CanvasTypographyFeatureName.SlashedZero => " Typography.SlashedZero=\"True\"",
-
-                _ => string.Empty
-            };
         }
     }
 }


### PR DESCRIPTION
Enables users to copy the previewed glyph with its correct [Typography](https://learn.microsoft.com/en-us/uwp/api/windows.ui.xaml.documents.typography) properties.

I'm pretty sure some typography mappings are redundant, but I’ve included them regardless.

https://github.com/user-attachments/assets/ad1cedce-925c-4be7-be26-0b49263467af

