### PR TITLE
HOTFIX: Prevent theme crash

### DIFF
--- a/CharacterMap/CharacterMap/Themes/SystemThemes.xaml
+++ b/CharacterMap/CharacterMap/Themes/SystemThemes.xaml
@@ -903,4 +903,6 @@
         <controls:SelectorVisualElement Style="{StaticResource VerticalRadioSelectorElementStyle}" />
     </DataTemplate>
 
+    <Style x:Key="PreviewTipHighContrastStyle" TargetType="controls:PreviewTip" />
+
 </ResourceDictionary>

--- a/CharacterMap/CharacterMap/Themes/ZuneThemeStyles.xaml
+++ b/CharacterMap/CharacterMap/Themes/ZuneThemeStyles.xaml
@@ -6252,6 +6252,8 @@
         <controls:SelectorVisualElement />
     </DataTemplate>
 
+    <Style x:Key="PreviewTipHighContrastStyle" TargetType="controls:PreviewTip" />
+
 
 
 </ResourceDictionary>


### PR DESCRIPTION
Windows 10 theme (and everything apart from Windows 11 theme) currently crash on launch. This fixes it. Sorry! :')


(Windows 10 will need a minor design update later, but this unblocks the immediate issue).